### PR TITLE
Add automatic formatter plugin

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -9,8 +9,11 @@
 
 set -e
 
+# Get the root of the project
+BASE_DIR="$(git rev-parse --show-toplevel)"
+
 # Run formatter to format files before commit
-mvn formatter:format &>/dev/null
+mvn -f "$BASE_DIR/pom.xml" formatter:format &>/dev/null
 
 # Find all files staged for commit
 filesStagedForCommit="$(git diff --name-only --cached)"

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# A hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, add this file to .git/hooks
+
+set -e
+
+# Run formatter to format files before commit
+mvn formatter:format &>/dev/null
+
+# Find all files staged for commit
+filesStagedForCommit="$(git diff --name-only --cached)"
+
+# Add all files back in case any where changed by formatter
+for file in $filesStagedForCommit
+do
+    git add $file
+done
+
+exit 0

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -15,7 +15,7 @@ mvn formatter:format &>/dev/null
 # Find all files staged for commit
 filesStagedForCommit="$(git diff --name-only --cached)"
 
-# Add all files back in case any where changed by formatter
+# Add all files back in case any were changed by formatter
 for file in $filesStagedForCommit
 do
     git add $file

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Password:
 
 For more information about H2 databases see the [H2 Database Engine](https://www.h2database.com/html/main.html).
 
+### Formatting
+
+The codebase is auto-formatted with the [formatter-maven-plugin](https://code.revelc.net/formatter-maven-plugin/) that will format all source code files in the `src/` and `test/` directories according to the settings in the `style.xml` file, which are based on eclipse profile settings.
+
+Run the `formatter:format` command to run the formatter. It is also bound to the `format` goal that will run as part of the `compile` phase. 
+
+You can also add the git hook in `.hooks` to your local `.git/hooks` folder to run the formatter on pre-commit.
+
 ## Contributors
 The _Puff_ project is looking for contributors to join the initiative!
 For information about progress, features under construction and opportunities to contribute see [our project board](https://github.com/benjaminkostiuk/unity-test/projects/1).

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,22 @@
 					<trimStackTrace>false</trimStackTrace>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>net.revelc.code.formatter</groupId>
+				<artifactId>formatter-maven-plugin</artifactId>
+				<version>2.15.0</version>
+				<configuration>
+					<configFile>${project.basedir}/style.xml</configFile>
+					<encoding>UTF-8</encoding>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>format</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>

--- a/src/main/java/com/unityTest/courseManagement/RestExceptionHandler.java
+++ b/src/main/java/com/unityTest/courseManagement/RestExceptionHandler.java
@@ -31,223 +31,227 @@ import javax.servlet.http.HttpServletRequest;
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
-    /**
-     * Handle MissingServletRequestParameterException. Thrown when a 'required' request parameter is missing.
-     *
-     * @param ex      MissingServletRequestParameterException
-     * @param headers HttpHeaders
-     * @param status  HttpStatus
-     * @param request WebRequest
-     * @return the ApiError object as response with 400 status code
-     */
-    @Override
-    protected ResponseEntity<Object> handleMissingServletRequestParameter(
-            MissingServletRequestParameterException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        String message = ExceptionMsg.MISSING_REQUEST_PARAMETER(ex.getParameterName());
-        return buildResponseEntity(new ApiError(HttpStatus.BAD_REQUEST, message, ex, request));
-    }
+	/**
+	 * Handle MissingServletRequestParameterException. Thrown when a 'required' request parameter is
+	 * missing.
+	 *
+	 * @param ex MissingServletRequestParameterException
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return the ApiError object as response with 400 status code
+	 */
+	@Override
+	protected ResponseEntity<Object> handleMissingServletRequestParameter(
+			MissingServletRequestParameterException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		String message = ExceptionMsg.MISSING_REQUEST_PARAMETER(ex.getParameterName());
+		return buildResponseEntity(new ApiError(HttpStatus.BAD_REQUEST, message, ex, request));
+	}
 
-    /**
-     * Handle HttpMediaTypeNotSupportedException. Thrown when MediaType is not supported.
-     *
-     * @param ex      HttpMediaTypeNotSupportedException
-     * @param headers HttpHeaders
-     * @param status  HttpStatus
-     * @param request WebRequest
-     * @return the ApiError object as response with 415 status code
-     */
-    @Override
-    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
-            HttpMediaTypeNotSupportedException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        String message = ExceptionMsg.HTTP_MEDIA_TYPE_NOT_SUPPORTED(ex.getContentType(), ex.getSupportedMediaTypes());
-        ApiError error = new ApiError(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ex.getLocalizedMessage(), ex, request);
-        error.setDebugMessage(message);
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handle HttpMediaTypeNotSupportedException. Thrown when MediaType is not supported.
+	 *
+	 * @param ex HttpMediaTypeNotSupportedException
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return the ApiError object as response with 415 status code
+	 */
+	@Override
+	protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+			HttpMediaTypeNotSupportedException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		String message = ExceptionMsg.HTTP_MEDIA_TYPE_NOT_SUPPORTED(ex.getContentType(), ex.getSupportedMediaTypes());
+		ApiError error = new ApiError(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ex.getLocalizedMessage(), ex, request);
+		error.setDebugMessage(message);
+		return buildResponseEntity(error);
+	}
 
-    /**
-     * Handle HttpRequestMethodNotSupportedException. Thrown when endpoint is called with unsupported HTTP verb.
-     *
-     * @param ex        HttpRequestMethodNotSupportedException
-     * @param headers   HttpHeaders
-     * @param status    HttpStatus
-     * @param request   WebRequest
-     * @return ApiError object as response with 405 status code
-     */
-    @Override
-    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
-            HttpRequestMethodNotSupportedException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        // Create debug message string
-        StringBuilder builder = new StringBuilder();
-        builder.append(ex.getMethod());
-        builder.append(" method is not supported for path. Supported methods are ");
-        ex.getSupportedHttpMethods().forEach(m -> builder.append(m.toString()).append(", "));
-        // Create ApiError object to return as response
-        ApiError error = new ApiError(HttpStatus.METHOD_NOT_ALLOWED, ExceptionMsg.HTTP_REQUEST_METHOD_NOT_SUPPORTED(ex.getMethod()), ex, request);
-        error.setDebugMessage(builder.substring(0, builder.length() - 2));
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handle HttpRequestMethodNotSupportedException. Thrown when endpoint is called with unsupported
+	 * HTTP verb.
+	 *
+	 * @param ex HttpRequestMethodNotSupportedException
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return ApiError object as response with 405 status code
+	 */
+	@Override
+	protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+			HttpRequestMethodNotSupportedException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		// Create debug message string
+		StringBuilder builder = new StringBuilder();
+		builder.append(ex.getMethod());
+		builder.append(" method is not supported for path. Supported methods are ");
+		ex.getSupportedHttpMethods().forEach(m -> builder.append(m.toString()).append(", "));
+		// Create ApiError object to return as response
+		ApiError error = new ApiError(
+				HttpStatus.METHOD_NOT_ALLOWED, ExceptionMsg.HTTP_REQUEST_METHOD_NOT_SUPPORTED(ex.getMethod()), ex,
+				request);
+		error.setDebugMessage(builder.substring(0, builder.length() - 2));
+		return buildResponseEntity(error);
+	}
 
-    /**
-     * Handle NoHandlerFoundException. Thrown when no handler exists for an endpoint.
-     * TODO IMPLEMENT NOTE: NOT CURRENTLY IMPLEMENTED
-     *
-     * @param ex        NoHandlerFoundException
-     * @param headers   HttpHeaders
-     * @param status    HttpStatus
-     * @param request   WebRequest
-     * @return ApiError object as response with 404 status code
-     */
-    @Override
-    protected ResponseEntity<Object> handleNoHandlerFoundException(
-            NoHandlerFoundException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        return buildResponseEntity(new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.NO_HANDLER_FOUND, ex, request));
-    }
+	/**
+	 * Handle NoHandlerFoundException. Thrown when no handler exists for an endpoint. TODO IMPLEMENT
+	 * NOTE: NOT CURRENTLY IMPLEMENTED
+	 *
+	 * @param ex NoHandlerFoundException
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return ApiError object as response with 404 status code
+	 */
+	@Override
+	protected ResponseEntity<Object> handleNoHandlerFoundException(
+			NoHandlerFoundException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		return buildResponseEntity(new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.NO_HANDLER_FOUND, ex, request));
+	}
 
-    /**
-     * Handle HttpMessageNotReadableException. Thrown when request JSON is malformed.
-     *
-     * @param ex        HttpMessageNotReadableException
-     * @param headers   HttpHeaders
-     * @param status    HttpStatus
-     * @param request   WebRequest
-     * @return ApiError object as response with 400 status code
-     */
-    @Override
-    protected ResponseEntity<Object> handleHttpMessageNotReadable(
-            HttpMessageNotReadableException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        return buildResponseEntity(new ApiError(HttpStatus.BAD_REQUEST, ExceptionMsg.MALFORMED_JSON_REQUEST, ex, request));
-    }
+	/**
+	 * Handle HttpMessageNotReadableException. Thrown when request JSON is malformed.
+	 *
+	 * @param ex HttpMessageNotReadableException
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return ApiError object as response with 400 status code
+	 */
+	@Override
+	protected ResponseEntity<Object> handleHttpMessageNotReadable(
+			HttpMessageNotReadableException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		return buildResponseEntity(
+			new ApiError(HttpStatus.BAD_REQUEST, ExceptionMsg.MALFORMED_JSON_REQUEST, ex, request));
+	}
 
-    /**
-     * Handle MethodArgumentNotValidException. Thrown when an object with @Valid fails validation.
-     *
-     * @param ex        MethodArgumentNotValidException that is thrown
-     * @param headers   HttpHeaders
-     * @param status    HttpStatus
-     * @param request   WebRequest
-     * @return ApiError object as response with 400 status code
-     */
-    @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        ApiError error = new ApiError(HttpStatus.BAD_REQUEST, ExceptionMsg.METHOD_ARGUMENT_NOT_VALID, ex, request);
-        error.setDebugMessage("Validation failed for argument");
-        // Add all field errors
-        ex.getBindingResult().getFieldErrors().forEach(error::addValidationError);
-        // Add all global validation errors
-        ex.getBindingResult().getGlobalErrors().forEach(error::addValidationError);
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handle MethodArgumentNotValidException. Thrown when an object with @Valid fails validation.
+	 *
+	 * @param ex MethodArgumentNotValidException that is thrown
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return ApiError object as response with 400 status code
+	 */
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(
+			MethodArgumentNotValidException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		ApiError error = new ApiError(HttpStatus.BAD_REQUEST, ExceptionMsg.METHOD_ARGUMENT_NOT_VALID, ex, request);
+		error.setDebugMessage("Validation failed for argument");
+		// Add all field errors
+		ex.getBindingResult().getFieldErrors().forEach(error::addValidationError);
+		// Add all global validation errors
+		ex.getBindingResult().getGlobalErrors().forEach(error::addValidationError);
+		return buildResponseEntity(error);
+	}
 
-    /**
-     * Handles javax.validation.ConstraintViolationException. Thrown when @Validated fails.
-     *
-     * @param ex        ConstraintViolationException
-     * @param headers   HttpHeaders
-     * @param status    HttpStatus
-     * @param request   WebRequest
-     * @return ApiError object as response with 400 status code
-     */
-    @ExceptionHandler(javax.validation.ConstraintViolationException.class)
-    protected ResponseEntity<Object> handleConstraintViolation(
-            javax.validation.ConstraintViolationException ex,
-            HttpHeaders headers,
-            HttpStatus status,
-            WebRequest request) {
-        ApiError error = new ApiError(HttpStatus.BAD_REQUEST, ExceptionMsg.CONSTRAINT_VALIDATION, ex, request);
-        error.setDebugMessage("Validation failed for argument");
-        // Add all constraint violation errors
-        ex.getConstraintViolations().forEach(error::addValidationError);
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handles javax.validation.ConstraintViolationException. Thrown when @Validated fails.
+	 *
+	 * @param ex ConstraintViolationException
+	 * @param headers HttpHeaders
+	 * @param status HttpStatus
+	 * @param request WebRequest
+	 * @return ApiError object as response with 400 status code
+	 */
+	@ExceptionHandler(javax.validation.ConstraintViolationException.class)
+	protected ResponseEntity<Object> handleConstraintViolation(
+			javax.validation.ConstraintViolationException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request) {
+		ApiError error = new ApiError(HttpStatus.BAD_REQUEST, ExceptionMsg.CONSTRAINT_VALIDATION, ex, request);
+		error.setDebugMessage("Validation failed for argument");
+		// Add all constraint violation errors
+		ex.getConstraintViolations().forEach(error::addValidationError);
+		return buildResponseEntity(error);
+	}
 
-    /**
-     * Handle ElementNotFoundException. Thrown when queried element cannot be found in database.
-     *
-     * @param ex        ElementNotFoundException that is thrown
-     * @param request   HttpServletRequest web request
-     * @return ApiError object as response with 404 status code
-     */
-    @ExceptionHandler(ElementNotFoundException.class)
-    protected ResponseEntity<Object> handleElementNotFound(
-            ElementNotFoundException ex,
-            HttpServletRequest request) {
-        ApiError error = new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.ELEMENT_NOT_FOUND, ex, request);
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handle ElementNotFoundException. Thrown when queried element cannot be found in database.
+	 *
+	 * @param ex ElementNotFoundException that is thrown
+	 * @param request HttpServletRequest web request
+	 * @return ApiError object as response with 404 status code
+	 */
+	@ExceptionHandler(ElementNotFoundException.class)
+	protected ResponseEntity<Object> handleElementNotFound(ElementNotFoundException ex, HttpServletRequest request) {
+		ApiError error = new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.ELEMENT_NOT_FOUND, ex, request);
+		return buildResponseEntity(error);
+	}
 
-    /**
-     * Handle DataIntegrityViolationException. Thrown when database attempts to perform an action that would violate
-     * it data integrity. Root causes are generally ConstraintViolationExceptions.
-     *
-     * @param ex        DataIntegrityViolationException
-     * @param request   HttpServletRequest
-     * @return ApiError object as response with 409 status code
-     */
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    protected ResponseEntity<Object> handleDataIntegrityViolation(
-            DataIntegrityViolationException ex,
-            HttpServletRequest request) {
-        if(ex.getCause() instanceof javax.validation.ConstraintViolationException
-            || ex.getCause() instanceof org.hibernate.exception.ConstraintViolationException) {
-            return buildResponseEntity(new ApiError(HttpStatus.CONFLICT, ExceptionMsg.DATABASE_CONFLICT, ex, request));
-        }
-        return buildResponseEntity(new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getLocalizedMessage(), ex.getCause(), request));
-    }
+	/**
+	 * Handle DataIntegrityViolationException. Thrown when database attempts to perform an action that
+	 * would violate it data integrity. Root causes are generally ConstraintViolationExceptions.
+	 *
+	 * @param ex DataIntegrityViolationException
+	 * @param request HttpServletRequest
+	 * @return ApiError object as response with 409 status code
+	 */
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	protected ResponseEntity<Object> handleDataIntegrityViolation(
+			DataIntegrityViolationException ex,
+			HttpServletRequest request) {
+		if (ex.getCause() instanceof javax.validation.ConstraintViolationException
+				|| ex.getCause() instanceof org.hibernate.exception.ConstraintViolationException) {
+			return buildResponseEntity(new ApiError(HttpStatus.CONFLICT, ExceptionMsg.DATABASE_CONFLICT, ex, request));
+		}
+		return buildResponseEntity(
+			new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getLocalizedMessage(), ex.getCause(), request));
+	}
 
-    /**
-     * Handle PropertyReferenceException. Thrown when property referenced in param does not exist.
-     *
-     * @param ex        PropertyReferenceException
-     * @param request   HttpServletRequest
-     * @return ApiError object as response with 400 status code
-     */
-    @ExceptionHandler(org.springframework.data.mapping.PropertyReferenceException.class)
-    protected ResponseEntity<Object> handlePropertyReferenceException(
-            PropertyReferenceException ex,
-            HttpServletRequest request) {
-        ApiError error = new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.PROPERTY_REFERENCE, ex, request);
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handle PropertyReferenceException. Thrown when property referenced in param does not exist.
+	 *
+	 * @param ex PropertyReferenceException
+	 * @param request HttpServletRequest
+	 * @return ApiError object as response with 400 status code
+	 */
+	@ExceptionHandler(org.springframework.data.mapping.PropertyReferenceException.class)
+	protected ResponseEntity<Object> handlePropertyReferenceException(
+			PropertyReferenceException ex,
+			HttpServletRequest request) {
+		ApiError error = new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.PROPERTY_REFERENCE, ex, request);
+		return buildResponseEntity(error);
+	}
 
-    /**
-     * Handle EmptyResultDataAccessException. Thrown when a result was expected to have at least one element but zero
-     * elements were actually returned.
-     *
-     * @param ex        EmptyResultDataAccessException
-     * @param request   HttpServletRequest
-     * @return ApiError object as response with 404 status code
-     */
-    @ExceptionHandler(org.springframework.dao.EmptyResultDataAccessException.class)
-    protected ResponseEntity<Object> handleEmptyResultDataAccess(
-            EmptyResultDataAccessException ex,
-            HttpServletRequest request) {
-        ApiError error = new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.ELEMENT_DOES_NOT_EXIST, ex, request);
-        return buildResponseEntity(error);
-    }
+	/**
+	 * Handle EmptyResultDataAccessException. Thrown when a result was expected to have at least one
+	 * element but zero elements were actually returned.
+	 *
+	 * @param ex EmptyResultDataAccessException
+	 * @param request HttpServletRequest
+	 * @return ApiError object as response with 404 status code
+	 */
+	@ExceptionHandler(org.springframework.dao.EmptyResultDataAccessException.class)
+	protected ResponseEntity<Object> handleEmptyResultDataAccess(
+			EmptyResultDataAccessException ex,
+			HttpServletRequest request) {
+		ApiError error = new ApiError(HttpStatus.NOT_FOUND, ExceptionMsg.ELEMENT_DOES_NOT_EXIST, ex, request);
+		return buildResponseEntity(error);
+	}
 
 
-    private ResponseEntity<Object> buildResponseEntity(ApiError apiError) {
-        return new ResponseEntity<>(apiError, apiError.getStatus());
-    }
+	private ResponseEntity<Object> buildResponseEntity(ApiError apiError) {
+		return new ResponseEntity<>(apiError, apiError.getStatus());
+	}
 
 }

--- a/src/main/java/com/unityTest/courseManagement/configuration/KeycloakSecurityConfig.java
+++ b/src/main/java/com/unityTest/courseManagement/configuration/KeycloakSecurityConfig.java
@@ -21,46 +21,50 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 @EnableGlobalMethodSecurity(jsr250Enabled = true)
 public class KeycloakSecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        super.configure(http);
-        http.csrf().disable().headers().frameOptions().disable();
-        http.authorizeRequests()
-                // Permit all swagger links
-                .antMatchers("/v2/api-docs",
-                        "/configuration/ui",
-                        "/swagger-resources/**",
-                        "/configuration/security",
-                        "/swagger-ui.html",
-                        "/webjars/**").permitAll()
-                // Allow h2
-                .antMatchers("/h2/**").permitAll()
-                // Allow actuator endpoints
-                .antMatchers("/actuator/health").permitAll()
-                .antMatchers("/actuator/info").permitAll()
-                // Authorize all other requests
-                .mvcMatchers("/**").hasRole("USER")
-                .anyRequest().authenticated();
-    }
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		super.configure(http);
+		http.csrf().disable().headers().frameOptions().disable();
+		http
+			.authorizeRequests()
+			// Permit all swagger links
+			.antMatchers(
+				"/v2/api-docs", "/configuration/ui", "/swagger-resources/**", "/configuration/security",
+				"/swagger-ui.html", "/webjars/**")
+			.permitAll()
+			// Allow h2
+			.antMatchers("/h2/**")
+			.permitAll()
+			// Allow actuator endpoints
+			.antMatchers("/actuator/health")
+			.permitAll()
+			.antMatchers("/actuator/info")
+			.permitAll()
+			// Authorize all other requests
+			.mvcMatchers("/**")
+			.hasRole("USER")
+			.anyRequest()
+			.authenticated();
+	}
 
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) {
-        SimpleAuthorityMapper grantedAuthorityMapper = new SimpleAuthorityMapper();
-        grantedAuthorityMapper.setPrefix("ROLE_");              // Prefix  with ROLE_
-        grantedAuthorityMapper.setConvertToUpperCase(true);     // Convert ROLE to uppercase
-        KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
-        keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(grantedAuthorityMapper);
-        auth.authenticationProvider(keycloakAuthenticationProvider);
-    }
+	@Autowired
+	public void configureGlobal(AuthenticationManagerBuilder auth) {
+		SimpleAuthorityMapper grantedAuthorityMapper = new SimpleAuthorityMapper();
+		grantedAuthorityMapper.setPrefix("ROLE_"); // Prefix with ROLE_
+		grantedAuthorityMapper.setConvertToUpperCase(true); // Convert ROLE to uppercase
+		KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
+		keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(grantedAuthorityMapper);
+		auth.authenticationProvider(keycloakAuthenticationProvider);
+	}
 
-    @Bean
-    @Override
-    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
-    }
+	@Bean
+	@Override
+	protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
+		return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+	}
 
-    @Bean
-    public KeycloakConfigResolver keycloakConfigResolver() {
-        return new KeycloakSpringBootConfigResolver();
-    }
+	@Bean
+	public KeycloakConfigResolver keycloakConfigResolver() {
+		return new KeycloakSpringBootConfigResolver();
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/configuration/SecurityTestConfig.java
+++ b/src/main/java/com/unityTest/courseManagement/configuration/SecurityTestConfig.java
@@ -12,15 +12,15 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @EnableWebSecurity
 public class SecurityTestConfig extends WebSecurityConfigurerAdapter {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests().antMatchers("/**").permitAll();
-        http.headers().frameOptions().disable();
-        http.csrf().disable();
-    }
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.authorizeRequests().antMatchers("/**").permitAll();
+		http.headers().frameOptions().disable();
+		http.csrf().disable();
+	}
 
-    @Override
-    public void configure(WebSecurity web) throws Exception {
-        web.ignoring().antMatchers("/**");
-    }
+	@Override
+	public void configure(WebSecurity web) throws Exception {
+		web.ignoring().antMatchers("/**");
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/configuration/Swagger2Config.java
+++ b/src/main/java/com/unityTest/courseManagement/configuration/Swagger2Config.java
@@ -29,129 +29,138 @@ import static springfox.documentation.schema.AlternateTypeRules.newRule;
 @EnableSwagger2
 public class Swagger2Config {
 
-    @Value("${swagger.api.title}")
-    private String title;
+	@Value("${swagger.api.title}")
+	private String title;
 
-    @Value("${swagger.api.description}")
-    private String description;
+	@Value("${swagger.api.description}")
+	private String description;
 
-    @Value("${swagger.api.contact.name}")
-    private String contactName;
+	@Value("${swagger.api.contact.name}")
+	private String contactName;
 
-    @Value("${swagger.api.contact.url}")
-    private String contactUrl;
+	@Value("${swagger.api.contact.url}")
+	private String contactUrl;
 
-    @Value("${swagger.api.contact.email}")
-    private String contactEmail;
+	@Value("${swagger.api.contact.email}")
+	private String contactEmail;
 
-    @Value("${swagger.api.license.name}")
-    private String licenseName;
+	@Value("${swagger.api.license.name}")
+	private String licenseName;
 
-    @Value("${swagger.api.license.url}")
-    private String licensceUrl;
+	@Value("${swagger.api.license.url}")
+	private String licensceUrl;
 
-    @Value("${swagger.api.version}")
-    private String version;
+	@Value("${swagger.api.version}")
+	private String version;
 
-    @Value("${keycloak.realm}")
-    private String realm;
+	@Value("${keycloak.realm}")
+	private String realm;
 
-    @Value("${swagger.auth.token-url}")
-    private String authTokenUrl;
+	@Value("${swagger.auth.token-url}")
+	private String authTokenUrl;
 
-    @Value("${swagger.auth.client-secret}")
-    private String authClientSecret;
+	@Value("${swagger.auth.client-secret}")
+	private String authClientSecret;
 
-    @Value("${swagger.auth.client-id}")
-    private String authClientId;
+	@Value("${swagger.auth.client-id}")
+	private String authClientId;
 
-    @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors
-                    .basePackage("com.unityTest.courseManagement.restImpl"))
-                .paths(PathSelectors.regex("/.*"))
-                .build()
-                .apiInfo(apiEndPointsInfo())
-                .securityContexts(Lists.newArrayList(securityContext()))
-                .securitySchemes(Lists.newArrayList(securitySchema()));
-    }
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.select()
+			.apis(RequestHandlerSelectors.basePackage("com.unityTest.courseManagement.restImpl"))
+			.paths(PathSelectors.regex("/.*"))
+			.build()
+			.apiInfo(apiEndPointsInfo())
+			.securityContexts(Lists.newArrayList(securityContext()))
+			.securitySchemes(Lists.newArrayList(securitySchema()));
+	}
 
-    @Bean
-    public SecurityConfiguration securityConfiguration() {
-        return new SecurityConfiguration(authClientId, authClientSecret, realm, "", "", Collections.emptyMap(), false);
-    }
+	@Bean
+	public SecurityConfiguration securityConfiguration() {
+		return new SecurityConfiguration(authClientId, authClientSecret, realm, "", "", Collections.emptyMap(), false);
+	}
 
-    private OAuth securitySchema() {
-        List<GrantType> grantTypes = Lists.newArrayList(new ResourceOwnerPasswordCredentialsGrant(authTokenUrl));
-        return new OAuth("oauth2", Collections.EMPTY_LIST, grantTypes);
-    }
+	private OAuth securitySchema() {
+		List<GrantType> grantTypes = Lists.newArrayList(new ResourceOwnerPasswordCredentialsGrant(authTokenUrl));
+		return new OAuth("oauth2", Collections.EMPTY_LIST, grantTypes);
+	}
 
-    private SecurityContext securityContext() {
-        return SecurityContext.builder()
-                .securityReferences(Lists.newArrayList(new SecurityReference("oauth2", new AuthorizationScope[0])))
-                .forPaths(PathSelectors.regex("/.*"))
-                .build();
-    }
+	private SecurityContext securityContext() {
+		return SecurityContext
+			.builder()
+			.securityReferences(Lists.newArrayList(new SecurityReference("oauth2", new AuthorizationScope[0])))
+			.forPaths(PathSelectors.regex("/.*"))
+			.build();
+	}
 
-    private ApiInfo apiEndPointsInfo() {
-        return new ApiInfoBuilder().title(title)
-            .description(description)
-            .contact(new Contact(contactName, contactUrl, contactEmail))
-            .license(licenseName)
-            .licenseUrl(licensceUrl)
-            .version(version)
-            .build();
-    }
+	private ApiInfo apiEndPointsInfo() {
+		return new ApiInfoBuilder()
+			.title(title)
+			.description(description)
+			.contact(new Contact(contactName, contactUrl, contactEmail))
+			.license(licenseName)
+			.licenseUrl(licensceUrl)
+			.version(version)
+			.build();
+	}
 
-    @Bean
-    public AlternateTypeRuleConvention springDataWebPropertiesConvention(final SpringDataWebProperties springDataWebProperties) {
-        return new AlternateTypeRuleConvention() {
-            @Override
-            public int getOrder() {
-                return Ordered.HIGHEST_PRECEDENCE;
-            }
-            @Override
-            public List<AlternateTypeRule> rules() {
-                return Collections.singletonList(
-                    // Set alternate definition for Pageable class
-                    newRule(Pageable.class, alternatePageableType(springDataWebProperties.getPageable(), springDataWebProperties.getSort()))
-                );
-            }
-        };
-    }
+	@Bean
+	public AlternateTypeRuleConvention springDataWebPropertiesConvention(
+			final SpringDataWebProperties springDataWebProperties) {
+		return new AlternateTypeRuleConvention() {
+			@Override
+			public int getOrder() {
+				return Ordered.HIGHEST_PRECEDENCE;
+			}
 
-    private Type alternatePageableType(SpringDataWebProperties.Pageable pageable, SpringDataWebProperties.Sort sort) {
-        final String firstPage = pageable.isOneIndexedParameters() ? "1" : "0";
-        return new AlternateTypeBuilder()
-            .fullyQualifiedClassName(
-                    String.format("%s.generated.%s",
-                            Pageable.class.getPackage().getName(),
-                            Pageable.class.getSimpleName()))
-            .property(property(pageable.getPageParameter(), Integer.class, ImmutableMap.of(
-                    "value", "Page " + (pageable.isOneIndexedParameters() ? "Number" : "Index"),
-                    "defaultValue", firstPage,
-                    "allowableValues", String.format("range[%s, %s]", firstPage, Integer.MAX_VALUE)
-            )))
-            .property(property(pageable.getSizeParameter(), Integer.class, ImmutableMap.of(
-                    "value", "Page Size",
-                    "defaultValue", String.valueOf(pageable.getDefaultPageSize()),
-                    "allowableValues", String.format("range[1, %s]", pageable.getMaxPageSize()),
-                    "example", String.valueOf(5)
-            )))
-            .property(property(sort.getSortParameter(), String[].class, ImmutableMap.of(
-                    "value", "Page Multi-Sort: fieldName,(asc|desc)"
-            )))
-            .build();
-    }
+			@Override
+			public List<AlternateTypeRule> rules() {
+				return Collections
+					.singletonList(
+						// Set alternate definition for Pageable class
+						newRule(
+							Pageable.class, alternatePageableType(
+								springDataWebProperties.getPageable(), springDataWebProperties.getSort())));
+			}
+		};
+	}
 
-    private AlternateTypePropertyBuilder property(String name, Class<?> type, Map<String, Object> parameters) {
-        return new AlternateTypePropertyBuilder()
-            .withName(name)
-            .withType(type)
-            .withCanRead(true)
-            .withCanWrite(true)
-            .withAnnotations(Collections.singletonList(AnnotationProxy.of(ApiParam.class, parameters)));
-    }
+	private Type alternatePageableType(SpringDataWebProperties.Pageable pageable, SpringDataWebProperties.Sort sort) {
+		final String firstPage = pageable.isOneIndexedParameters() ? "1" : "0";
+		return new AlternateTypeBuilder()
+			.fullyQualifiedClassName(
+				String.format("%s.generated.%s", Pageable.class.getPackage().getName(), Pageable.class.getSimpleName()))
+			.property(
+				property(
+					pageable.getPageParameter(), Integer.class,
+					ImmutableMap
+						.of(
+							"value", "Page " + (pageable.isOneIndexedParameters() ? "Number" : "Index"), "defaultValue",
+							firstPage, "allowableValues",
+							String.format("range[%s, %s]", firstPage, Integer.MAX_VALUE))))
+			.property(
+				property(
+					pageable.getSizeParameter(), Integer.class,
+					ImmutableMap
+						.of(
+							"value", "Page Size", "defaultValue", String.valueOf(pageable.getDefaultPageSize()),
+							"allowableValues", String.format("range[1, %s]", pageable.getMaxPageSize()), "example",
+							String.valueOf(5))))
+			.property(
+				property(
+					sort.getSortParameter(), String[].class,
+					ImmutableMap.of("value", "Page Multi-Sort: fieldName,(asc|desc)")))
+			.build();
+	}
+
+	private AlternateTypePropertyBuilder property(String name, Class<?> type, Map<String, Object> parameters) {
+		return new AlternateTypePropertyBuilder()
+			.withName(name)
+			.withType(type)
+			.withCanRead(true)
+			.withCanWrite(true)
+			.withAnnotations(Collections.singletonList(AnnotationProxy.of(ApiParam.class, parameters)));
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/constants/ExceptionMsg.java
+++ b/src/main/java/com/unityTest/courseManagement/constants/ExceptionMsg.java
@@ -8,30 +8,30 @@ import java.util.List;
  * Contains all exception messages for RestExceptionHandler
  */
 public class ExceptionMsg {
-    public static final String NO_HANDLER_FOUND = "No handler found for path";
-    public static final String MALFORMED_JSON_REQUEST = "Malformed JSON request";
-    public static final String METHOD_ARGUMENT_NOT_VALID = "Validation error";
-    public static final String CONSTRAINT_VALIDATION = "Validation error";
-    public static final String ELEMENT_NOT_FOUND = "Element not found";
-    public static final String DATABASE_CONFLICT = "Database conflict";
-    public static final String PROPERTY_REFERENCE = "Property does not exist";
-    public static final String ELEMENT_DOES_NOT_EXIST = "Element does not exist";
+	public static final String NO_HANDLER_FOUND = "No handler found for path";
+	public static final String MALFORMED_JSON_REQUEST = "Malformed JSON request";
+	public static final String METHOD_ARGUMENT_NOT_VALID = "Validation error";
+	public static final String CONSTRAINT_VALIDATION = "Validation error";
+	public static final String ELEMENT_NOT_FOUND = "Element not found";
+	public static final String DATABASE_CONFLICT = "Database conflict";
+	public static final String PROPERTY_REFERENCE = "Property does not exist";
+	public static final String ELEMENT_DOES_NOT_EXIST = "Element does not exist";
 
-    public static String MISSING_REQUEST_PARAMETER(String name) {
-        return String.format("%s parameter is missing", name);
-    }
+	public static String MISSING_REQUEST_PARAMETER(String name) {
+		return String.format("%s parameter is missing", name);
+	}
 
-    public static String HTTP_MEDIA_TYPE_NOT_SUPPORTED(MediaType type, List<MediaType> supportedTypes) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(type);
-        builder.append(" media type is not supported. Supported media types are ");
-        supportedTypes.forEach(t -> builder.append(t).append(", "));
-        return builder.substring(0, builder.length() - 2);
-    }
+	public static String HTTP_MEDIA_TYPE_NOT_SUPPORTED(MediaType type, List<MediaType> supportedTypes) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(type);
+		builder.append(" media type is not supported. Supported media types are ");
+		supportedTypes.forEach(t -> builder.append(t).append(", "));
+		return builder.substring(0, builder.length() - 2);
+	}
 
-    public static String HTTP_REQUEST_METHOD_NOT_SUPPORTED(String method) {
-        return String.format("Request method '%s' not supported", method);
-    }
+	public static String HTTP_REQUEST_METHOD_NOT_SUPPORTED(String method) {
+		return String.format("Request method '%s' not supported", method);
+	}
 
 
 }

--- a/src/main/java/com/unityTest/courseManagement/entity/AssignmentEnrollment.java
+++ b/src/main/java/com/unityTest/courseManagement/entity/AssignmentEnrollment.java
@@ -17,33 +17,31 @@ import javax.persistence.*;
 @Table(name = "ASSIGNMENT_ENROLLMENT")
 public class AssignmentEnrollment {
 
-    @Id
-    @Column(name = "ID")
-    @GeneratedValue(generator = "sequence-generator")
-    @GenericGenerator(
-            name = "sequence-generator",
-            strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-            parameters = {
-                    @org.hibernate.annotations.Parameter(name = "sequence_name", value = "ASSIGNMENT_ENROLLMENT_SEQUENCE"),
-                    @org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
-                    @org.hibernate.annotations.Parameter(name = "increment_size", value = "1")
-            }
-    )
-    private int id;
+	@Id
+	@Column(name = "ID")
+	@GeneratedValue(generator = "sequence-generator")
+	@GenericGenerator(
+		name = "sequence-generator",
+		strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+		parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "ASSIGNMENT_ENROLLMENT_SEQUENCE"),
+			@org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
+			@org.hibernate.annotations.Parameter(name = "increment_size", value = "1")})
+	private int id;
 
-    // Assignment user is enrolled in
-//    @ApiModelProperty(value = "Enrolled assignment")
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "ASSIGNMENT_ID", referencedColumnName = "ID")
-//    private Assignment course;
+	// Assignment user is enrolled in
+	// @ApiModelProperty(value = "Enrolled assignment")
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "ASSIGNMENT_ID", referencedColumnName = "ID")
+	// private Assignment course;
 
-    // User id
-    @JsonIgnore
-    @Column(name = "USER_ID")
-    private String userId;
+	// User id
+	@JsonIgnore
+	@Column(name = "USER_ID")
+	private String userId;
 
-    // True if user has pinned the course
-    @ApiModelProperty(value = "True if assignment is pinned for user", required = true, example = "false")
-    @Column(name = "PINNED")
-    private boolean isPinned = false;
+	// True if user has pinned the course
+	@ApiModelProperty(value = "True if assignment is pinned for user", required = true, example = "false")
+	@Column(name = "PINNED")
+	private boolean isPinned = false;
 }

--- a/src/main/java/com/unityTest/courseManagement/entity/Course.java
+++ b/src/main/java/com/unityTest/courseManagement/entity/Course.java
@@ -31,7 +31,8 @@ public class Course {
 	@GenericGenerator(
 		name = "sequence-generator",
 		strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-		parameters = {@org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_SEQUENCE"),
+		parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_SEQUENCE"),
 			@org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
 			@org.hibernate.annotations.Parameter(name = "increment_size", value = "1")})
 	private int id;

--- a/src/main/java/com/unityTest/courseManagement/entity/Course.java
+++ b/src/main/java/com/unityTest/courseManagement/entity/Course.java
@@ -25,44 +25,41 @@ import javax.validation.constraints.NotNull;
 @Table(name = "COURSE")
 public class Course {
 
-    @Id
-    @Column(name = "ID")
-    @GeneratedValue(generator = "sequence-generator")
-    @GenericGenerator(
-            name = "sequence-generator",
-            strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-            parameters = {
-                    @org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_SEQUENCE"),
-                    @org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
-                    @org.hibernate.annotations.Parameter(name = "increment_size", value = "1")
-            }
-    )
-    private int id;
+	@Id
+	@Column(name = "ID")
+	@GeneratedValue(generator = "sequence-generator")
+	@GenericGenerator(
+		name = "sequence-generator",
+		strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+		parameters = {@org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_SEQUENCE"),
+			@org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
+			@org.hibernate.annotations.Parameter(name = "increment_size", value = "1")})
+	private int id;
 
-    // Course code
-    @ApiModelProperty(value = "Course code", required = true, example = "COMPSCI 1JC3")
-    @NotBlank
-    @Column(name = "CODE")
-    private String code;
+	// Course code
+	@ApiModelProperty(value = "Course code", required = true, example = "COMPSCI 1JC3")
+	@NotBlank
+	@Column(name = "CODE")
+	private String code;
 
-    // Course level, between 1 and 4
-    @ApiModelProperty(value = "Program level", required = true, example = "1")
-    @Min(1)
-    @Max(4)
-    @Column(name = "LEVEL")
-    private int level;
+	// Course level, between 1 and 4
+	@ApiModelProperty(value = "Program level", required = true, example = "1")
+	@Min(1)
+	@Max(4)
+	@Column(name = "LEVEL")
+	private int level;
 
-    // School term
-    @ApiModelProperty(value = "School term", required = true, allowableValues = "FALL, WINTER, SPRING, SUMMER")
-    @Enumerated(EnumType.STRING)
-    @NotNull
-    @Column(name = "TERM")
-    private Term term;
+	// School term
+	@ApiModelProperty(value = "School term", required = true, allowableValues = "FALL, WINTER, SPRING, SUMMER")
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	@Column(name = "TERM")
+	private Term term;
 
-    // Academic year
-    @ApiModelProperty(value = "Academic year", required = true, example = "2020")
-    @NotNull
-    @Column(name = "ACADEMIC_YEAR")
-    private Integer academicYear;
+	// Academic year
+	@ApiModelProperty(value = "Academic year", required = true, example = "2020")
+	@NotNull
+	@Column(name = "ACADEMIC_YEAR")
+	private Integer academicYear;
 }
 

--- a/src/main/java/com/unityTest/courseManagement/entity/CourseAttribute.java
+++ b/src/main/java/com/unityTest/courseManagement/entity/CourseAttribute.java
@@ -24,36 +24,33 @@ import javax.validation.constraints.NotNull;
 @Table(name = "COURSE_ATTR")
 public class CourseAttribute {
 
-    @Id
-    @Column(name = "Id")
-    @JsonIgnore
-    @GeneratedValue(generator = "sequence-generator")
-    @GenericGenerator(
-            name = "sequence-generator",
-            strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-            parameters = {
-                    @org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_ATTR_SEQUENCE"),
-                    @org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
-                    @org.hibernate.annotations.Parameter(name = "increment_size", value = "1")
-            }
-    )
-    private int id;
+	@Id
+	@Column(name = "Id")
+	@JsonIgnore
+	@GeneratedValue(generator = "sequence-generator")
+	@GenericGenerator(
+		name = "sequence-generator",
+		strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+		parameters = {@org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_ATTR_SEQUENCE"),
+			@org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
+			@org.hibernate.annotations.Parameter(name = "increment_size", value = "1")})
+	private int id;
 
-    // Associated course
-    @JsonIgnore
-    @Column(name = "COURSE_ID")
-    private Integer courseId;
+	// Associated course
+	@JsonIgnore
+	@Column(name = "COURSE_ID")
+	private Integer courseId;
 
-    // Attribute name
-    @ApiModelProperty(value = "Course attribute name", required = true, example = "professorName")
-    @Enumerated(EnumType.STRING)
-    @NotNull
-    @Column(name = "ATTR_NAME")
-    private CourseAttributeName name;
+	// Attribute name
+	@ApiModelProperty(value = "Course attribute name", required = true, example = "professorName")
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	@Column(name = "ATTR_NAME")
+	private CourseAttributeName name;
 
-    // Attribute value
-    @ApiModelProperty(value = "Course attribute value", required = true, example = "William M. Farmer")
-    @NotBlank
-    @Column(name = "ATTR_VALUE")
-    private String value;
+	// Attribute value
+	@ApiModelProperty(value = "Course attribute value", required = true, example = "William M. Farmer")
+	@NotBlank
+	@Column(name = "ATTR_VALUE")
+	private String value;
 }

--- a/src/main/java/com/unityTest/courseManagement/entity/CourseAttribute.java
+++ b/src/main/java/com/unityTest/courseManagement/entity/CourseAttribute.java
@@ -31,7 +31,8 @@ public class CourseAttribute {
 	@GenericGenerator(
 		name = "sequence-generator",
 		strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
-		parameters = {@org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_ATTR_SEQUENCE"),
+		parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "COURSE_ATTR_SEQUENCE"),
 			@org.hibernate.annotations.Parameter(name = "initial_value", value = "1000"),
 			@org.hibernate.annotations.Parameter(name = "increment_size", value = "1")})
 	private int id;

--- a/src/main/java/com/unityTest/courseManagement/exception/ElementNotFoundException.java
+++ b/src/main/java/com/unityTest/courseManagement/exception/ElementNotFoundException.java
@@ -7,11 +7,12 @@ import java.util.Map;
 
 public class ElementNotFoundException extends RuntimeException {
 
-    public ElementNotFoundException(Class clazz, Object... queryParamsMap) {
-        super(ElementNotFoundException.generateMessage(clazz.getSimpleName(), Utils.toMap(String.class, String.class, queryParamsMap)));
-    }
+	public ElementNotFoundException(Class clazz, Object... queryParamsMap) {
+		super(ElementNotFoundException
+			.generateMessage(clazz.getSimpleName(), Utils.toMap(String.class, String.class, queryParamsMap)));
+	}
 
-    private static String generateMessage(String entity, Map<String, String> searchParams) {
-        return String.format("Could not find %s for query parameters %s", StringUtils.capitalize(entity), searchParams);
-    }
+	private static String generateMessage(String entity, Map<String, String> searchParams) {
+		return String.format("Could not find %s for query parameters %s", StringUtils.capitalize(entity), searchParams);
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/models/CourseAttributeName.java
+++ b/src/main/java/com/unityTest/courseManagement/models/CourseAttributeName.java
@@ -1,14 +1,13 @@
 package com.unityTest.courseManagement.models;
 
 /**
- * Attributes of a course
- * Names should match those returned as part of CourseAttributeView
+ * Attributes of a course Names should match those returned as part of CourseAttributeView
  */
 public enum CourseAttributeName {
-    title,
-    description,
-    professorName,
-    sections,
-    weight,
-    prerequisites
+	title,
+	description,
+	professorName,
+	sections,
+	weight,
+	prerequisites
 }

--- a/src/main/java/com/unityTest/courseManagement/models/Term.java
+++ b/src/main/java/com/unityTest/courseManagement/models/Term.java
@@ -4,8 +4,8 @@ package com.unityTest.courseManagement.models;
  * Academic semesters
  */
 public enum Term {
-    WINTER,
-    SPRING,
-    SUMMER,
-    FALL
+	WINTER,
+	SPRING,
+	SUMMER,
+	FALL
 }

--- a/src/main/java/com/unityTest/courseManagement/models/api/response/CourseAttributeView.java
+++ b/src/main/java/com/unityTest/courseManagement/models/api/response/CourseAttributeView.java
@@ -19,35 +19,42 @@ import java.util.List;
 @NoArgsConstructor
 public class CourseAttributeView {
 
-    @ApiModelProperty(value = "Course title", example = "Introduction to functional programming")
-    private String title;
+	@ApiModelProperty(value = "Course title", example = "Introduction to functional programming")
+	private String title;
 
-    @ApiModelProperty(value = "Course description", example = "Basic computability models; The Church-Turing thesis, complexity classes; P versus NP;")
-    private String description;
+	@ApiModelProperty(
+		value = "Course description",
+		example = "Basic computability models; The Church-Turing thesis, complexity classes; P versus NP;")
+	private String description;
 
-    @ApiModelProperty(value = "Course professor", example = "Dr. William Farmer")
-    private String professorName;
+	@ApiModelProperty(value = "Course professor", example = "Dr. William Farmer")
+	private String professorName;
 
-    @ApiModelProperty(value = "Course sections", example = "C01, C02")
-    private String sections;
+	@ApiModelProperty(value = "Course sections", example = "C01, C02")
+	private String sections;
 
-    @ApiModelProperty(value = "Course weight", example = "3 units")
-    private String weight;
+	@ApiModelProperty(value = "Course weight", example = "3 units")
+	private String weight;
 
-    @ApiModelProperty(value = "Course prerequisites", example = "COMPSCI 2FA3, COMPSCI 2CO3")
-    private String prerequisites;
+	@ApiModelProperty(value = "Course prerequisites", example = "COMPSCI 2FA3, COMPSCI 2CO3")
+	private String prerequisites;
 
-    // Course attribute view constructor
-    // Build a CourseAttributeView from a list of CourseAttributes
-    public CourseAttributeView(List<CourseAttribute> attributes) {
-        for (CourseAttribute attribute : attributes) {
-            try {
-                Field field = CourseAttributeView.class.getDeclaredField(attribute.getName().toString());
-                field.set(this, attribute.getValue());
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                log.error(String.format("Failed to find field %s with error %s.", attribute.getName().toString(), e.getLocalizedMessage()));
-            }
-        }
-    }
+	// Course attribute view constructor
+	// Build a CourseAttributeView from a list of CourseAttributes
+	public CourseAttributeView(List<CourseAttribute> attributes) {
+		for (CourseAttribute attribute : attributes) {
+			try {
+				Field field = CourseAttributeView.class.getDeclaredField(attribute.getName().toString());
+				field.set(this, attribute.getValue());
+			} catch (NoSuchFieldException | IllegalAccessException e) {
+				log
+					.error(
+						String
+							.format(
+								"Failed to find field %s with error %s.", attribute.getName().toString(),
+								e.getLocalizedMessage()));
+			}
+		}
+	}
 }
 

--- a/src/main/java/com/unityTest/courseManagement/models/api/response/page/BasePage.java
+++ b/src/main/java/com/unityTest/courseManagement/models/api/response/page/BasePage.java
@@ -11,67 +11,67 @@ import java.util.List;
 @Data
 public class BasePage<T> {
 
-    @Data
-    @ApiModel(value = "PageInfo", description = "Provides details about the page returned")
-    private class PageInfo {
-        @ApiModelProperty(value = "True if page request is sorted", example = "false")
-        private boolean isSorted;
+	@Data
+	@ApiModel(value = "PageInfo", description = "Provides details about the page returned")
+	private class PageInfo {
+		@ApiModelProperty(value = "True if page request is sorted", example = "false")
+		private boolean isSorted;
 
-        @ApiModelProperty(value = "Page number", example = "0")
-        private int pageNumber;
+		@ApiModelProperty(value = "Page number", example = "0")
+		private int pageNumber;
 
-        @ApiModelProperty(value = "Total number of pages", example = "2")
-        private int totalPages;
+		@ApiModelProperty(value = "Total number of pages", example = "2")
+		private int totalPages;
 
-        @ApiModelProperty(value = "Size of page returned", example = "3")
-        private int pageSize;
+		@ApiModelProperty(value = "Size of page returned", example = "3")
+		private int pageSize;
 
-        @ApiModelProperty(value = "Element offset in page")
-        private long offset;
+		@ApiModelProperty(value = "Element offset in page")
+		private long offset;
 
-        PageInfo(Pageable pageable, int totalPages) {
-            this.isSorted = pageable.getSort().isSorted();
-            this.pageNumber = pageable.getPageNumber();
-            this.totalPages = totalPages;
-            this.pageSize = pageable.getPageSize();
-            this.offset = pageable.getOffset();
-        }
-    }
+		PageInfo(Pageable pageable, int totalPages) {
+			this.isSorted = pageable.getSort().isSorted();
+			this.pageNumber = pageable.getPageNumber();
+			this.totalPages = totalPages;
+			this.pageSize = pageable.getPageSize();
+			this.offset = pageable.getOffset();
+		}
+	}
 
-    @ApiModelProperty(value = "Number of elements returned", example = "1")
-    private int count;
+	@ApiModelProperty(value = "Number of elements returned", example = "1")
+	private int count;
 
-    @ApiModelProperty(value = "Elements returned")
-    private List<T> data;
+	@ApiModelProperty(value = "Elements returned")
+	private List<T> data;
 
-    @ApiModelProperty(value = "Information about the returned page")
-    private PageInfo pageable;
+	@ApiModelProperty(value = "Information about the returned page")
+	private PageInfo pageable;
 
-    @ApiModelProperty(value = "Total number of elements", example = "5")
-    private long totalElements;
+	@ApiModelProperty(value = "Total number of elements", example = "5")
+	private long totalElements;
 
-    @ApiModelProperty(value = "True if the request shows the last page", example = "false")
-    private boolean isLast;
+	@ApiModelProperty(value = "True if the request shows the last page", example = "false")
+	private boolean isLast;
 
-    @ApiModelProperty(value = "True if the request shows the first page", example = "true")
-    private boolean isFirst;
+	@ApiModelProperty(value = "True if the request shows the first page", example = "true")
+	private boolean isFirst;
 
-    @ApiModelProperty(value = "True if there exists more pages with elements", example = "true")
-    private boolean hasMoreData;
+	@ApiModelProperty(value = "True if there exists more pages with elements", example = "true")
+	private boolean hasMoreData;
 
-    @ApiModelProperty(value = "True if the page contains no elements", example = "false")
-    private boolean isEmpty;
+	@ApiModelProperty(value = "True if the page contains no elements", example = "false")
+	private boolean isEmpty;
 
-    public BasePage(Page<T> page) {
-        this.count = page.getNumberOfElements();
-        this.data = page.getContent();
-        this.pageable = new PageInfo(page.getPageable(), page.getTotalPages());
-        this.totalElements = page.getTotalElements();
-        this.isLast = page.isLast();
-        this.isFirst = page.isFirst();
-        this.hasMoreData = page.getNumber() < page.getTotalPages() - 1;
-        this.isEmpty = page.isEmpty();
-    }
+	public BasePage(Page<T> page) {
+		this.count = page.getNumberOfElements();
+		this.data = page.getContent();
+		this.pageable = new PageInfo(page.getPageable(), page.getTotalPages());
+		this.totalElements = page.getTotalElements();
+		this.isLast = page.isLast();
+		this.isFirst = page.isFirst();
+		this.hasMoreData = page.getNumber() < page.getTotalPages() - 1;
+		this.isEmpty = page.isEmpty();
+	}
 }
 
 

--- a/src/main/java/com/unityTest/courseManagement/models/api/response/page/CoursePage.java
+++ b/src/main/java/com/unityTest/courseManagement/models/api/response/page/CoursePage.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 
 @ApiModel(value = "CoursePage", description = "Page request for courses")
 public class CoursePage extends BasePage<Course> {
-    public CoursePage(Page<Course> page) {
-        super(page);
-    }
+	public CoursePage(Page<Course> page) {
+		super(page);
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/models/error/ApiError.java
+++ b/src/main/java/com/unityTest/courseManagement/models/error/ApiError.java
@@ -24,89 +24,91 @@ import java.util.List;
 @ApiModel(value = "ApiError", description = "REST Api Error")
 public class ApiError {
 
-    @ApiModelProperty(example = "2020-12-19T01:00:26")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'hh:mm:ss")
-    private LocalDateTime timestamp;
+	@ApiModelProperty(example = "2020-12-19T01:00:26")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'hh:mm:ss")
+	private LocalDateTime timestamp;
 
-    @ApiModelProperty
-    private Integer code;
+	@ApiModelProperty
+	private Integer code;
 
-    @ApiModelProperty
-    private HttpStatus status;
+	@ApiModelProperty
+	private HttpStatus status;
 
-    @ApiModelProperty
-    private String message;
+	@ApiModelProperty
+	private String message;
 
-    @ApiModelProperty
-    private String debugMessage;
+	@ApiModelProperty
+	private String debugMessage;
 
-    @ApiModelProperty
-    private String path;
+	@ApiModelProperty
+	private String path;
 
-    @ApiModelProperty
-    private List<ApiSubError> subErrors = new ArrayList<>();
+	@ApiModelProperty
+	private List<ApiSubError> subErrors = new ArrayList<>();
 
-    private ApiError() {
-        this.timestamp = LocalDateTime.now();
-    }
+	private ApiError() {
+		this.timestamp = LocalDateTime.now();
+	}
 
-    public ApiError(HttpStatus status, String message, Throwable ex) {
-        this();
-        this.status = status;
-        this.code = status.value();
-        this.message = message;
-        this.debugMessage = ex.getLocalizedMessage();
-    }
+	public ApiError(HttpStatus status, String message, Throwable ex) {
+		this();
+		this.status = status;
+		this.code = status.value();
+		this.message = message;
+		this.debugMessage = ex.getLocalizedMessage();
+	}
 
-    private ApiError(HttpStatus status, String message, Throwable ex, String path) {
-        this(status, message, ex);
-        this.path = path;
-    }
+	private ApiError(HttpStatus status, String message, Throwable ex, String path) {
+		this(status, message, ex);
+		this.path = path;
+	}
 
-    public ApiError(HttpStatus status, String message, Throwable ex, WebRequest request) {
-        this(status, message, ex, ((ServletWebRequest) request).getRequest().getRequestURI());
-    }
+	public ApiError(HttpStatus status, String message, Throwable ex, WebRequest request) {
+		this(status, message, ex, ((ServletWebRequest) request).getRequest().getRequestURI());
+	}
 
-    public ApiError(HttpStatus status, String message, Throwable ex, HttpServletRequest request) {
-        this(status, message, ex, request.getRequestURI());
-    }
+	public ApiError(HttpStatus status, String message, Throwable ex, HttpServletRequest request) {
+		this(status, message, ex, request.getRequestURI());
+	}
 
-    private void addSubError(ApiSubError subError) {
-        this.subErrors.add(subError);
-    }
+	private void addSubError(ApiSubError subError) {
+		this.subErrors.add(subError);
+	}
 
-    private void addValidationError(String object, String field, Object rejectedValue, String message) {
-        addSubError(new ApiValidationError(object, field, rejectedValue, message));
-    }
+	private void addValidationError(String object, String field, Object rejectedValue, String message) {
+		addSubError(new ApiValidationError(object, field, rejectedValue, message));
+	}
 
-    private void addValidationError(String object, String message) {
-        addSubError(new ApiValidationError(object, message));
-    }
+	private void addValidationError(String object, String message) {
+		addSubError(new ApiValidationError(object, message));
+	}
 
-    /**
-     * Add a ObjectError validation error as a sub error. Usually when a @Valid validation fails.
-     *
-     * @param objectError ObjectError to be added as a validation sub error.
-     */
-    public void addValidationError(ObjectError objectError) {
-        if(objectError instanceof FieldError) {
-            FieldError fieldError = (FieldError) objectError;
-            this.addValidationError(fieldError.getObjectName(), fieldError.getField(), fieldError.getRejectedValue(), fieldError.getDefaultMessage());
-        } else {
-            this.addValidationError(objectError.getObjectName(), objectError.getDefaultMessage());
-        }
-    }
+	/**
+	 * Add a ObjectError validation error as a sub error. Usually when a @Valid validation fails.
+	 *
+	 * @param objectError ObjectError to be added as a validation sub error.
+	 */
+	public void addValidationError(ObjectError objectError) {
+		if (objectError instanceof FieldError) {
+			FieldError fieldError = (FieldError) objectError;
+			this
+				.addValidationError(
+					fieldError.getObjectName(), fieldError.getField(), fieldError.getRejectedValue(),
+					fieldError.getDefaultMessage());
+		} else {
+			this.addValidationError(objectError.getObjectName(), objectError.getDefaultMessage());
+		}
+	}
 
-    /**
-     * Add a ConstraintViolation as a sub error. Usually when a @Validated validation fails.
-     *
-     * @param cv ConstraintViolation error to be added as a validation sub error.
-     */
-    public void addValidationError(ConstraintViolation<?> cv) {
-        this.addValidationError(
-                cv.getRootBeanClass().getSimpleName(),
-                ((PathImpl) cv.getPropertyPath()).getLeafNode().asString(),
-                cv.getInvalidValue(),
-                cv.getMessage());
-    }
+	/**
+	 * Add a ConstraintViolation as a sub error. Usually when a @Validated validation fails.
+	 *
+	 * @param cv ConstraintViolation error to be added as a validation sub error.
+	 */
+	public void addValidationError(ConstraintViolation<?> cv) {
+		this
+			.addValidationError(
+				cv.getRootBeanClass().getSimpleName(), ((PathImpl) cv.getPropertyPath()).getLeafNode().asString(),
+				cv.getInvalidValue(), cv.getMessage());
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/models/error/ApiValidationError.java
+++ b/src/main/java/com/unityTest/courseManagement/models/error/ApiValidationError.java
@@ -14,27 +14,27 @@ import lombok.EqualsAndHashCode;
 @ApiModel
 public class ApiValidationError extends ApiSubError {
 
-    @ApiModelProperty
-    private String object;
+	@ApiModelProperty
+	private String object;
 
-    @ApiModelProperty
-    private String field;
+	@ApiModelProperty
+	private String field;
 
-    @ApiModelProperty
-    private Object rejectedValue;
+	@ApiModelProperty
+	private Object rejectedValue;
 
-    @ApiModelProperty
-    private String message;
+	@ApiModelProperty
+	private String message;
 
-    public ApiValidationError(String object, String message) {
-        this.object = object;
-        this.message = message;
-    }
+	public ApiValidationError(String object, String message) {
+		this.object = object;
+		this.message = message;
+	}
 
-    public ApiValidationError(String object, String field, Object rejectedValue, String message) {
-        this(object,  message);
-        this.field = field;
-        this.rejectedValue = rejectedValue;
-    }
+	public ApiValidationError(String object, String field, Object rejectedValue, String message) {
+		this(object, message);
+		this.field = field;
+		this.rejectedValue = rejectedValue;
+	}
 
 }

--- a/src/main/java/com/unityTest/courseManagement/repository/CourseAttrRepository.java
+++ b/src/main/java/com/unityTest/courseManagement/repository/CourseAttrRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CourseAttrRepository extends
-        JpaRepository<CourseAttribute, Integer>, JpaSpecificationExecutor<CourseAttribute> {
+public interface CourseAttrRepository
+		extends JpaRepository<CourseAttribute, Integer>, JpaSpecificationExecutor<CourseAttribute> {
 }

--- a/src/main/java/com/unityTest/courseManagement/restApi/BaseApi.java
+++ b/src/main/java/com/unityTest/courseManagement/restApi/BaseApi.java
@@ -3,14 +3,9 @@ package com.unityTest.courseManagement.restApi;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
-@ApiResponses({
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 405, message = "Method Not Supported"),
-        @ApiResponse(code = 409, message = "Database conflict"),
-        @ApiResponse(code = 415, message = "MediaType Not Supported")
-})
+@ApiResponses({@ApiResponse(code = 400, message = "Bad Request"), @ApiResponse(code = 401, message = "Unauthorized"),
+	@ApiResponse(code = 403, message = "Forbidden"), @ApiResponse(code = 404, message = "Not Found"),
+	@ApiResponse(code = 405, message = "Method Not Supported"), @ApiResponse(code = 409, message = "Database conflict"),
+	@ApiResponse(code = 415, message = "MediaType Not Supported")})
 interface BaseApi {
 }

--- a/src/main/java/com/unityTest/courseManagement/restApi/BaseApi.java
+++ b/src/main/java/com/unityTest/courseManagement/restApi/BaseApi.java
@@ -3,9 +3,13 @@ package com.unityTest.courseManagement.restApi;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
-@ApiResponses({@ApiResponse(code = 400, message = "Bad Request"), @ApiResponse(code = 401, message = "Unauthorized"),
-	@ApiResponse(code = 403, message = "Forbidden"), @ApiResponse(code = 404, message = "Not Found"),
-	@ApiResponse(code = 405, message = "Method Not Supported"), @ApiResponse(code = 409, message = "Database conflict"),
+@ApiResponses({
+	@ApiResponse(code = 400, message = "Bad Request"),
+	@ApiResponse(code = 401, message = "Unauthorized"),
+	@ApiResponse(code = 403, message = "Forbidden"),
+	@ApiResponse(code = 404, message = "Not Found"),
+	@ApiResponse(code = 405, message = "Method Not Supported"),
+	@ApiResponse(code = 409, message = "Database conflict"),
 	@ApiResponse(code = 415, message = "MediaType Not Supported")})
 interface BaseApi {
 }

--- a/src/main/java/com/unityTest/courseManagement/restApi/CourseApi.java
+++ b/src/main/java/com/unityTest/courseManagement/restApi/CourseApi.java
@@ -18,69 +18,99 @@ import javax.validation.Valid;
 @Validated
 @RequestMapping(value = "/course")
 public interface CourseApi extends BaseApi {
-    /**
-     * POST endpoint to create a Course
-     * @return Created course
-     */
-    @ApiOperation(value = "Create or update a course", nickname = "createCourse", response = Course.class, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ApiResponses({ @ApiResponse(code = 201, message = "Created", response = Course.class) })
-    @PostMapping(value = "",  produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<Course> createCourse(@ApiParam(value = "Course to create", required = true) @Valid @RequestBody Course course);
+	/**
+	 * POST endpoint to create a Course
+	 * 
+	 * @return Created course
+	 */
+	@ApiOperation(
+		value = "Create or update a course",
+		nickname = "createCourse",
+		response = Course.class,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE)
+	@ApiResponses({@ApiResponse(code = 201, message = "Created", response = Course.class)})
+	@PostMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<Course> createCourse(
+			@ApiParam(value = "Course to create", required = true) @Valid @RequestBody Course course);
 
-    /**
-     * GET endpoint to retrieve courses
-     * Filter by id, code, level, term and academic year
-     * @return List of Course objects matching criterion
-     */
-    @ApiOperation(value = "Retrieve a list of courses", nickname = "getCourses", response = CoursePage.class, produces = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<CoursePage> getCourses(
-            Pageable pageable,
-            @ApiParam("Course id") @RequestParam(value = "id", required = false) Integer id,
-            @ApiParam("Course code") @RequestParam(value = "code", required = false) String code,
-            @ApiParam("Course level") @RequestParam(value = "level", required = false) Integer level,
-            @ApiParam("Course term") @RequestParam(value = "term", required = false) String term,
-            @ApiParam("Course academic year") @RequestParam(value = "academicYear", required = false) Integer academicYear
-    );
+	/**
+	 * GET endpoint to retrieve courses Filter by id, code, level, term and academic year
+	 * 
+	 * @return List of Course objects matching criterion
+	 */
+	@ApiOperation(
+		value = "Retrieve a list of courses",
+		nickname = "getCourses",
+		response = CoursePage.class,
+		produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<CoursePage> getCourses(
+			Pageable pageable,
+			@ApiParam("Course id") @RequestParam(value = "id", required = false) Integer id,
+			@ApiParam("Course code") @RequestParam(value = "code", required = false) String code,
+			@ApiParam("Course level") @RequestParam(value = "level", required = false) Integer level,
+			@ApiParam("Course term") @RequestParam(value = "term", required = false) String term,
+			@ApiParam("Course academic year")
+			@RequestParam(value = "academicYear", required = false) Integer academicYear);
 
-    /**
-     * DELETE endpoint to delete a course
-     * @param courseId Id of course to delete
-     */
-    @ApiOperation(value = "Delete a course", nickname = "deleteCourse")
-    @ResponseStatus(code = HttpStatus.NO_CONTENT)
-    @DeleteMapping(value = "/{courseId}")
-    void deleteCourse(@ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId);
+	/**
+	 * DELETE endpoint to delete a course
+	 * 
+	 * @param courseId Id of course to delete
+	 */
+	@ApiOperation(value = "Delete a course", nickname = "deleteCourse")
+	@ResponseStatus(code = HttpStatus.NO_CONTENT)
+	@DeleteMapping(value = "/{courseId}")
+	void deleteCourse(
+			@ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId);
 
-    /**
-     * POST endpoint to create an attribute for a course
-     * @return Create course attribute
-     */
-    @ApiOperation(value = "Create or update a course attribute", nickname = "createCourseAttr", response = CourseAttribute.class, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ApiResponses({ @ApiResponse(code = 201, message = "Created", response = CourseAttribute.class) })
-    @PostMapping(value = "/{courseId}/attr", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<CourseAttribute> createCourseAttr(
-            @ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId,
-            @ApiParam(value = "Course attribute to create", required = true) @Valid @RequestBody CourseAttribute courseAttr
-    );
+	/**
+	 * POST endpoint to create an attribute for a course
+	 * 
+	 * @return Create course attribute
+	 */
+	@ApiOperation(
+		value = "Create or update a course attribute",
+		nickname = "createCourseAttr",
+		response = CourseAttribute.class,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE)
+	@ApiResponses({@ApiResponse(code = 201, message = "Created", response = CourseAttribute.class)})
+	@PostMapping(
+		value = "/{courseId}/attr",
+		consumes = MediaType.APPLICATION_JSON_VALUE,
+		produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<CourseAttribute> createCourseAttr(
+			@ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId,
+			@ApiParam(value = "Course attribute to create", required = true) @Valid
+			@RequestBody CourseAttribute courseAttr);
 
-    /**
-     * GET endpoint to retrieve attributes for a course
-     * @return Collection of attributes for a course
-     */
-    @ApiOperation(value = "Get attributes for a course", nickname = "getCourseAttrs", response = CourseAttributeView.class, produces = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping(value = "/{courseId}/attr", produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<CourseAttributeView> getCourseAttrs(@ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId);
+	/**
+	 * GET endpoint to retrieve attributes for a course
+	 * 
+	 * @return Collection of attributes for a course
+	 */
+	@ApiOperation(
+		value = "Get attributes for a course",
+		nickname = "getCourseAttrs",
+		response = CourseAttributeView.class,
+		produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(value = "/{courseId}/attr", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<CourseAttributeView> getCourseAttrs(
+			@ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId);
 
-    /**
-     * DELETE endpoint to delete a course attribute
-     * @param courseId Id of course attribute belongs to
-     * @param attributeName Name of attribute to delete
-     */
-    @ApiOperation(value = "Delete a course attribute", nickname = "deleteCourseAttr")
-    @ResponseStatus(code = HttpStatus.NO_CONTENT)
-    @DeleteMapping(value = "/{courseId}/attr/{attributeName}")
-    void deleteCourseAttr(
-            @ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId,
-            @ApiParam(value = "Course attribute name", required = true) @PathVariable(value = "attributeName") String attributeName);
+	/**
+	 * DELETE endpoint to delete a course attribute
+	 * 
+	 * @param courseId Id of course attribute belongs to
+	 * @param attributeName Name of attribute to delete
+	 */
+	@ApiOperation(value = "Delete a course attribute", nickname = "deleteCourseAttr")
+	@ResponseStatus(code = HttpStatus.NO_CONTENT)
+	@DeleteMapping(value = "/{courseId}/attr/{attributeName}")
+	void deleteCourseAttr(
+			@ApiParam(value = "Course id", required = true) @PathVariable(value = "courseId") Integer courseId,
+			@ApiParam(value = "Course attribute name", required = true)
+			@PathVariable(value = "attributeName") String attributeName);
 }

--- a/src/main/java/com/unityTest/courseManagement/restImpl/CourseController.java
+++ b/src/main/java/com/unityTest/courseManagement/restImpl/CourseController.java
@@ -26,65 +26,74 @@ import java.util.List;
 @RestController
 public class CourseController implements CourseApi {
 
-    @Autowired
-    private CourseService courseService;
+	@Autowired
+	private CourseService courseService;
 
-    @Override
-    @RolesAllowed("ROLE_ADMIN")
-    public ResponseEntity<Course> createCourse(Course course) {
-        return new ResponseEntity<>(courseService.createCourse(course), HttpStatus.CREATED);
-    }
+	@Override
+	@RolesAllowed("ROLE_ADMIN")
+	public ResponseEntity<Course> createCourse(Course course) {
+		return new ResponseEntity<>(courseService.createCourse(course), HttpStatus.CREATED);
+	}
 
-    @Override
-    public ResponseEntity<CoursePage> getCourses(Pageable pageable, Integer id, String code, Integer level, String term, Integer academicYear) {
-        // Convert term to Enum before searching
-        Term termEnum = null;
-        if(term != null) {
-            try { termEnum = Term.valueOf(term); }
-            catch(IllegalArgumentException e) { throw new HttpMessageNotReadableException("Not one of accepted values"); }
-        }
-        // Retrieve results using service
-        CoursePage page = new CoursePage(courseService.getCourses(pageable, id, code, level, termEnum, academicYear));
-        return new ResponseEntity<>(page, HttpStatus.OK);
-    }
+	@Override
+	public ResponseEntity<CoursePage> getCourses(
+			Pageable pageable,
+			Integer id,
+			String code,
+			Integer level,
+			String term,
+			Integer academicYear) {
+		// Convert term to Enum before searching
+		Term termEnum = null;
+		if (term != null) {
+			try {
+				termEnum = Term.valueOf(term);
+			} catch (IllegalArgumentException e) {
+				throw new HttpMessageNotReadableException("Not one of accepted values");
+			}
+		}
+		// Retrieve results using service
+		CoursePage page = new CoursePage(courseService.getCourses(pageable, id, code, level, termEnum, academicYear));
+		return new ResponseEntity<>(page, HttpStatus.OK);
+	}
 
-    @Override
-    @RolesAllowed("ROLE_ADMIN")
-    public void deleteCourse(Integer courseId) {
-        courseService.deleteCourse(courseId);
-    }
+	@Override
+	@RolesAllowed("ROLE_ADMIN")
+	public void deleteCourse(Integer courseId) {
+		courseService.deleteCourse(courseId);
+	}
 
-    @Override
-    @RolesAllowed("ROLE_ADMIN")
-    public ResponseEntity<CourseAttribute> createCourseAttr(Integer courseId, CourseAttribute courseAttr) {
-        // Find and and set course id for attribute
-        Course course = courseService.getCourseById(courseId);
-        courseAttr.setCourseId(course.getId());
-        return new ResponseEntity<>(courseService.createCourseAttr(courseAttr), HttpStatus.CREATED);
-    }
+	@Override
+	@RolesAllowed("ROLE_ADMIN")
+	public ResponseEntity<CourseAttribute> createCourseAttr(Integer courseId, CourseAttribute courseAttr) {
+		// Find and and set course id for attribute
+		Course course = courseService.getCourseById(courseId);
+		courseAttr.setCourseId(course.getId());
+		return new ResponseEntity<>(courseService.createCourseAttr(courseAttr), HttpStatus.CREATED);
+	}
 
-    @Override
-    public ResponseEntity<CourseAttributeView> getCourseAttrs(Integer courseId) {
-        // Get all attributes for the course
-        List<CourseAttribute> attributes = courseService.getCourseAttributes(null, courseId, null);
-        // Build CourseAttributeView to return
-        CourseAttributeView response = new CourseAttributeView(attributes);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
+	@Override
+	public ResponseEntity<CourseAttributeView> getCourseAttrs(Integer courseId) {
+		// Get all attributes for the course
+		List<CourseAttribute> attributes = courseService.getCourseAttributes(null, courseId, null);
+		// Build CourseAttributeView to return
+		CourseAttributeView response = new CourseAttributeView(attributes);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
 
-    @Override
-    @RolesAllowed("ROLE_ADMIN")
-    public void deleteCourseAttr(Integer courseId, String attributeName) {
-        // Parse attribute name
-        CourseAttributeName name;
-        try {
-            name = Utils.parseToEnum(attributeName, CourseAttributeName.class);
-        } catch (IllegalArgumentException e) {
-            throw new HttpMessageNotReadableException("Not one of allowed values of CourseAttributeName.");
-        }
+	@Override
+	@RolesAllowed("ROLE_ADMIN")
+	public void deleteCourseAttr(Integer courseId, String attributeName) {
+		// Parse attribute name
+		CourseAttributeName name;
+		try {
+			name = Utils.parseToEnum(attributeName, CourseAttributeName.class);
+		} catch (IllegalArgumentException e) {
+			throw new HttpMessageNotReadableException("Not one of allowed values of CourseAttributeName.");
+		}
 
-        // Get matching attributes and delete them
-        List<CourseAttribute> attributes = courseService.getCourseAttributes(null, courseId, name);
-        attributes.forEach(a -> courseService.deleteCourseAttr(a.getId()));
-    }
+		// Get matching attributes and delete them
+		List<CourseAttribute> attributes = courseService.getCourseAttributes(null, courseId, name);
+		attributes.forEach(a -> courseService.deleteCourseAttr(a.getId()));
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/service/CourseService.java
+++ b/src/main/java/com/unityTest/courseManagement/service/CourseService.java
@@ -22,137 +22,153 @@ import java.util.Optional;
 @Service
 public class CourseService {
 
-    @Autowired
-    private CourseRepository courseRepository;
+	@Autowired
+	private CourseRepository courseRepository;
 
-    @Autowired
-    private CourseAttrRepository courseAttrRepository;
+	@Autowired
+	private CourseAttrRepository courseAttrRepository;
 
-    /**
-     * Create or update a course
-     *
-     * @param course Course to create or update
-     * @return Course created
-     */
-    public Course createCourse(Course course) {
-        return courseRepository.save(course);
-    }
+	/**
+	 * Create or update a course
+	 *
+	 * @param course Course to create or update
+	 * @return Course created
+	 */
+	public Course createCourse(Course course) {
+		return courseRepository.save(course);
+	}
 
-    /**
-     * Get a list of courses that match the passed arguments
-     *
-     * @param id           Id of course to fetch
-     * @param code         Course code to match
-     * @param level        Course level to match
-     * @param term         Course term to match
-     * @param academicYear Course academic year to match
-     * @return List of courses with fields matching the passed arguments
-     */
-    public List<Course> getCourses(Integer id, String code, Integer level, Term term, Integer academicYear) {
-        return getCourses(Pageable.unpaged(), id, code, level, term, academicYear).getContent();
-    }
+	/**
+	 * Get a list of courses that match the passed arguments
+	 *
+	 * @param id Id of course to fetch
+	 * @param code Course code to match
+	 * @param level Course level to match
+	 * @param term Course term to match
+	 * @param academicYear Course academic year to match
+	 * @return List of courses with fields matching the passed arguments
+	 */
+	public List<Course> getCourses(Integer id, String code, Integer level, Term term, Integer academicYear) {
+		return getCourses(Pageable.unpaged(), id, code, level, term, academicYear).getContent();
+	}
 
-    /**
-     * Get a Page view of courses that match the passed arguments
-     *
-     * @param pageable     Pageable object specifying page size, sort and index
-     * @param id           Id of course to fetch
-     * @param code         Course code to match
-     * @param level        Course level to match
-     * @param term         Course term to match
-     * @param academicYear Course academic year to match
-     * @return Page view of courses from repository matching passed arguments and formatted using the pageable param
-     */
-    public Page<Course> getCourses(Pageable pageable, Integer id, String code, Integer level, Term term, Integer academicYear) {
-        Specification<Course> spec = new AndSpecification<Course>()
-                .equal(id, Course_.ID)
-                .equal(code, Course_.CODE)
-                .equal(level, Course_.LEVEL)
-                .equal(term, Course_.TERM)
-                .equal(academicYear, Course_.ACADEMIC_YEAR).getSpec();
-        return courseRepository.findAll(spec, pageable);
-    }
+	/**
+	 * Get a Page view of courses that match the passed arguments
+	 *
+	 * @param pageable Pageable object specifying page size, sort and index
+	 * @param id Id of course to fetch
+	 * @param code Course code to match
+	 * @param level Course level to match
+	 * @param term Course term to match
+	 * @param academicYear Course academic year to match
+	 * @return Page view of courses from repository matching passed arguments and formatted using the
+	 *         pageable param
+	 */
+	public Page<Course> getCourses(
+			Pageable pageable,
+			Integer id,
+			String code,
+			Integer level,
+			Term term,
+			Integer academicYear) {
+		Specification<Course> spec = new AndSpecification<Course>()
+			.equal(id, Course_.ID)
+			.equal(code, Course_.CODE)
+			.equal(level, Course_.LEVEL)
+			.equal(term, Course_.TERM)
+			.equal(academicYear, Course_.ACADEMIC_YEAR)
+			.getSpec();
+		return courseRepository.findAll(spec, pageable);
+	}
 
-    /**
-     * Finds and returns a course by its id
-     *
-     * @param id Id of course to find
-     * @return Course with matching id from JPA repository
-     * @throws ElementNotFoundException if no course with matching id can be found
-     */
-    public Course getCourseById(int id) throws ElementNotFoundException {
-        Optional<Course> opt = courseRepository.findById(id);
-        // Throw exception if element for id does not exist
-        if (!opt.isPresent()) throw new ElementNotFoundException(Course.class, "id", String.valueOf(id));
-        return opt.get();
-    }
+	/**
+	 * Finds and returns a course by its id
+	 *
+	 * @param id Id of course to find
+	 * @return Course with matching id from JPA repository
+	 * @throws ElementNotFoundException if no course with matching id can be found
+	 */
+	public Course getCourseById(int id) throws ElementNotFoundException {
+		Optional<Course> opt = courseRepository.findById(id);
+		// Throw exception if element for id does not exist
+		if (!opt.isPresent())
+			throw new ElementNotFoundException(Course.class, "id", String.valueOf(id));
+		return opt.get();
+	}
 
-    /**
-     * Delete a course
-     *
-     * @param id Id of course to delete
-     */
-    public void deleteCourse(int id) {
-        courseRepository.deleteById(id);
-    }
+	/**
+	 * Delete a course
+	 *
+	 * @param id Id of course to delete
+	 */
+	public void deleteCourse(int id) {
+		courseRepository.deleteById(id);
+	}
 
-    /**
-     * Create or update an attribute for a course
-     *
-     * @param attribute CourseAttribute to create
-     * @return CourseAttribute created
-     */
-    public CourseAttribute createCourseAttr(CourseAttribute attribute) {
-        // Check if attribute already exists
-        Specification<CourseAttribute> spec = new AndSpecification<CourseAttribute>()
-                .equal(attribute.getCourseId(), CourseAttribute_.COURSE_ID)
-                .equal(attribute.getName(), CourseAttribute_.NAME).getSpec();
-        Optional<CourseAttribute> opt = courseAttrRepository.findOne(spec);
-        // Overwrite value of existing attribute
-        if (opt.isPresent()) {
-            CourseAttribute existingAttribute = opt.get();
-            existingAttribute.setValue(attribute.getValue());
-            return courseAttrRepository.save(existingAttribute);
-        }
-        // Otherwise, create a new attribute
-        return courseAttrRepository.save(attribute);
-    }
+	/**
+	 * Create or update an attribute for a course
+	 *
+	 * @param attribute CourseAttribute to create
+	 * @return CourseAttribute created
+	 */
+	public CourseAttribute createCourseAttr(CourseAttribute attribute) {
+		// Check if attribute already exists
+		Specification<CourseAttribute> spec = new AndSpecification<CourseAttribute>()
+			.equal(attribute.getCourseId(), CourseAttribute_.COURSE_ID)
+			.equal(attribute.getName(), CourseAttribute_.NAME)
+			.getSpec();
+		Optional<CourseAttribute> opt = courseAttrRepository.findOne(spec);
+		// Overwrite value of existing attribute
+		if (opt.isPresent()) {
+			CourseAttribute existingAttribute = opt.get();
+			existingAttribute.setValue(attribute.getValue());
+			return courseAttrRepository.save(existingAttribute);
+		}
+		// Otherwise, create a new attribute
+		return courseAttrRepository.save(attribute);
+	}
 
-    /**
-     * Get a list of course attributes that match the passed arguments
-     *
-     * @param id       Id of CourseAttribute to find
-     * @param courseId CourseAttribute courseId to match
-     * @param name     CourseAttributeName to match
-     * @return List of course attributes with fields matching the passed arguments
-     */
-    public List<CourseAttribute> getCourseAttributes(Integer id, Integer courseId, CourseAttributeName name) {
-        return getCourseAttributes(Pageable.unpaged(), id, courseId, name).getContent();
-    }
+	/**
+	 * Get a list of course attributes that match the passed arguments
+	 *
+	 * @param id Id of CourseAttribute to find
+	 * @param courseId CourseAttribute courseId to match
+	 * @param name CourseAttributeName to match
+	 * @return List of course attributes with fields matching the passed arguments
+	 */
+	public List<CourseAttribute> getCourseAttributes(Integer id, Integer courseId, CourseAttributeName name) {
+		return getCourseAttributes(Pageable.unpaged(), id, courseId, name).getContent();
+	}
 
-    /**
-     * Get a Page view of course attributes that match the passed arguments
-     *
-     * @param pageable Pageable object specifying page size, sort and index
-     * @param id       Id of CourseAttribute to find
-     * @param courseId CourseAttribute courseId to match
-     * @param name     CourseAttributeName to match
-     * @return Page view of course attributes from repository matching passed arguments and formatted using the pageable param
-     */
-    public Page<CourseAttribute> getCourseAttributes(Pageable pageable, Integer id, Integer courseId, CourseAttributeName name) {
-        Specification<CourseAttribute> spec = new AndSpecification<CourseAttribute>()
-                .equal(id, CourseAttribute_.ID)
-                .equal(courseId, CourseAttribute_.COURSE_ID)
-                .equal(name, CourseAttribute_.NAME).getSpec();
-        return courseAttrRepository.findAll(spec, pageable);
-    }
+	/**
+	 * Get a Page view of course attributes that match the passed arguments
+	 *
+	 * @param pageable Pageable object specifying page size, sort and index
+	 * @param id Id of CourseAttribute to find
+	 * @param courseId CourseAttribute courseId to match
+	 * @param name CourseAttributeName to match
+	 * @return Page view of course attributes from repository matching passed arguments and formatted
+	 *         using the pageable param
+	 */
+	public Page<CourseAttribute> getCourseAttributes(
+			Pageable pageable,
+			Integer id,
+			Integer courseId,
+			CourseAttributeName name) {
+		Specification<CourseAttribute> spec = new AndSpecification<CourseAttribute>()
+			.equal(id, CourseAttribute_.ID)
+			.equal(courseId, CourseAttribute_.COURSE_ID)
+			.equal(name, CourseAttribute_.NAME)
+			.getSpec();
+		return courseAttrRepository.findAll(spec, pageable);
+	}
 
-    /**
-     * Delete a course attribute
-     *
-     * @param id Id of course attribute to delete
-     */
-    public void deleteCourseAttr(int id) {
-        courseAttrRepository.deleteById(id);
-    }
+	/**
+	 * Delete a course attribute
+	 *
+	 * @param id Id of course attribute to delete
+	 */
+	public void deleteCourseAttr(int id) {
+		courseAttrRepository.deleteById(id);
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/utils/AnnotationProxy.java
+++ b/src/main/java/com/unityTest/courseManagement/utils/AnnotationProxy.java
@@ -15,24 +15,23 @@ import java.util.Map;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Accessors(fluent = true)
 public class AnnotationProxy implements Annotation, InvocationHandler {
-    @Getter
-    private final Class<? extends Annotation> annotationType;
-    private final Map<String, Object> values;
+	@Getter
+	private final Class<? extends Annotation> annotationType;
+	private final Map<String, Object> values;
 
-    public static <A extends Annotation> A of(Class<A> annotation, Map<String, Object> values) {
-        return (A) Proxy.newProxyInstance(
-            annotation.getClassLoader(),
-            new Class[]{annotation},
-            new AnnotationProxy(
-                annotation,
-                new HashMap<String, Object>(values) {{
-                    put("annotationType", annotation); // Required because getDefaultValue() returns null for this call
-                }}
-            )
-        );
-    }
+	public static <A extends Annotation> A of(Class<A> annotation, Map<String, Object> values) {
+		return (A) Proxy
+			.newProxyInstance(
+				annotation.getClassLoader(), new Class[] {annotation},
+				new AnnotationProxy(annotation, new HashMap<String, Object>(values) {
+					{
+						put("annotationType", annotation); // Required because getDefaultValue() returns null for this
+															// call
+					}
+				}));
+	}
 
-    public Object invoke(Object proxy, Method method, Object[] args) {
-        return values.getOrDefault(method.getName(), method.getDefaultValue());
-    }
+	public Object invoke(Object proxy, Method method, Object[] args) {
+		return values.getOrDefault(method.getName(), method.getDefaultValue());
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/utils/Utils.java
+++ b/src/main/java/com/unityTest/courseManagement/utils/Utils.java
@@ -8,24 +8,28 @@ import java.util.stream.IntStream;
 
 public class Utils {
 
-    // TODO Change mapping if necessary
-    public static <K, V> Map<K, V> toMap(
-            Class<K> keyType, Class<V> valueType, Object... entries) {
-        if (entries.length % 2 == 1)
-            throw new IllegalArgumentException("Invalid entries");
-        return IntStream.range(0, entries.length / 2).map(i -> i * 2)
-                .collect(HashMap::new,
-                        (m, i) -> m.put(keyType.cast(entries[i]), valueType.cast(entries[i + 1])),
-                        Map::putAll);
-    }
+	// TODO Change mapping if necessary
+	public static <K, V> Map<K, V> toMap(Class<K> keyType, Class<V> valueType, Object... entries) {
+		if (entries.length % 2 == 1)
+			throw new IllegalArgumentException("Invalid entries");
+		return IntStream
+			.range(0, entries.length / 2)
+			.map(i -> i * 2)
+			.collect(
+				HashMap::new, (m, i) -> m.put(keyType.cast(entries[i]), valueType.cast(entries[i + 1])), Map::putAll);
+	}
 
-    public static <E extends Enum<E>> E parseToEnum(String string, Class<E> clazz) {
-        // Convert string to enum value
-        E value = null;
-        if(string != null) {
-            try { value = Enum.valueOf(clazz, string); }
-            catch (IllegalArgumentException e) { throw new IllegalArgumentException(String.format("Not one of accepted value for %s", clazz.getCanonicalName())); }
-        }
-        return value;
-    }
+	public static <E extends Enum<E>> E parseToEnum(String string, Class<E> clazz) {
+		// Convert string to enum value
+		E value = null;
+		if (string != null) {
+			try {
+				value = Enum.valueOf(clazz, string);
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException(
+						String.format("Not one of accepted value for %s", clazz.getCanonicalName()));
+			}
+		}
+		return value;
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/utils/specification/AndSpecification.java
+++ b/src/main/java/com/unityTest/courseManagement/utils/specification/AndSpecification.java
@@ -3,14 +3,15 @@ package com.unityTest.courseManagement.utils.specification;
 import org.springframework.data.jpa.domain.Specification;
 
 public class AndSpecification<T> extends SpecificationBuilder<T> {
-    /**
-     * Combine specifications with AND operation
-     * @param spec First specification
-     * @param specToAdd Specification to add on to first specification
-     * @return Specification combining both specs with AND operation
-     */
-    @Override
-    protected Specification<T> combineSpecifications(Specification<T> spec, Specification<T> specToAdd) {
-        return spec.and(specToAdd);
-    }
+	/**
+	 * Combine specifications with AND operation
+	 * 
+	 * @param spec First specification
+	 * @param specToAdd Specification to add on to first specification
+	 * @return Specification combining both specs with AND operation
+	 */
+	@Override
+	protected Specification<T> combineSpecifications(Specification<T> spec, Specification<T> specToAdd) {
+		return spec.and(specToAdd);
+	}
 }

--- a/src/main/java/com/unityTest/courseManagement/utils/specification/SpecificationBuilder.java
+++ b/src/main/java/com/unityTest/courseManagement/utils/specification/SpecificationBuilder.java
@@ -9,78 +9,88 @@ import javax.persistence.criteria.*;
 
 public abstract class SpecificationBuilder<T> {
 
-    // Specification being built
-    private Specification<T> specification;
+	// Specification being built
+	private Specification<T> specification;
 
-    public SpecificationBuilder() {
-        this.specification = Specification.where(null);
-    }
+	public SpecificationBuilder() {
+		this.specification = Specification.where(null);
+	}
 
-    /**
-     * Extract the specification built from the builder
-     * @return Specification built by the builder
-     */
-    public Specification<T> getSpec() {
-        return this.specification;
-    }
+	/**
+	 * Extract the specification built from the builder
+	 * 
+	 * @return Specification built by the builder
+	 */
+	public Specification<T> getSpec() {
+		return this.specification;
+	}
 
-    /**
-     * Specify the behavior of your Specification builder when combining multiple query criterion
-     * @param spec First specification
-     * @param specToAdd Specification to add on to first specification
-     * @return Combined Specification according to chosen behavior
-     */
-    protected abstract Specification<T> combineSpecifications(Specification<T> spec, Specification<T> specToAdd);
+	/**
+	 * Specify the behavior of your Specification builder when combining multiple query criterion
+	 * 
+	 * @param spec First specification
+	 * @param specToAdd Specification to add on to first specification
+	 * @return Combined Specification according to chosen behavior
+	 */
+	protected abstract Specification<T> combineSpecifications(Specification<T> spec, Specification<T> specToAdd);
 
-    /**
-     * Combine and set the specification according to the chained specification behavior
-     * @param specToAdd Specification to combine with the specification being built
-     */
-    private void combineAndSetSpecification(Specification<T> specToAdd) {
-        this.specification = this.combineSpecifications(this.specification, specToAdd);
-    }
+	/**
+	 * Combine and set the specification according to the chained specification behavior
+	 * 
+	 * @param specToAdd Specification to combine with the specification being built
+	 */
+	private void combineAndSetSpecification(Specification<T> specToAdd) {
+		this.specification = this.combineSpecifications(this.specification, specToAdd);
+	}
 
-    // Add Specification with criteria where x = y
-    public <V> SpecificationBuilder<T> equal(V value, String attr, String... attrs) {
-        if(value != null) this.combineAndSetSpecification(this.buildSpec(Operator.EQUALS, value, attr, attrs));
-        return this;
-    }
+	// Add Specification with criteria where x = y
+	public <V> SpecificationBuilder<T> equal(V value, String attr, String... attrs) {
+		if (value != null)
+			this.combineAndSetSpecification(this.buildSpec(Operator.EQUALS, value, attr, attrs));
+		return this;
+	}
 
-    /**
-     * Build a specification for an operation
-     * @param operator Operator for specification
-     * @param value Value to compare to
-     * @param attr Field of <T> to compare against
-     * @param attrs Sub-fields of attr to compare against
-     * @param <V> Type of value
-     * @return Specification comparing attribute specified and value with the given operator
-     */
-    private <V> Specification<T> buildSpec(Operator operator, V value, String attr, String... attrs) {
-        return new Specification<T>() {
-            @Override
-            public Predicate toPredicate(Root<T> root, CriteriaQuery<?> criteriaQuery, CriteriaBuilder criteriaBuilder) {
-                // Build path
-                Path path = root.get(attr);
-                if(ArrayUtils.isNotEmpty(attrs)) {
-                    for(String attribute : attrs) path = path.get(attr);
-                }
-                // Return specification with correct operation
-                switch (operator) {
-                    case EQUALS:
-                        return criteriaBuilder.equal(path, value);
-                    default:
-                        throw new IllegalArgumentException("Operation not supported. Operation must be a member of Operator enum.");
-                }
-            }
-        };
-    }
+	/**
+	 * Build a specification for an operation
+	 * 
+	 * @param operator Operator for specification
+	 * @param value Value to compare to
+	 * @param attr Field of <T> to compare against
+	 * @param attrs Sub-fields of attr to compare against
+	 * @param <V> Type of value
+	 * @return Specification comparing attribute specified and value with the given operator
+	 */
+	private <V> Specification<T> buildSpec(Operator operator, V value, String attr, String... attrs) {
+		return new Specification<T>() {
+			@Override
+			public Predicate toPredicate(
+					Root<T> root,
+					CriteriaQuery<?> criteriaQuery,
+					CriteriaBuilder criteriaBuilder) {
+				// Build path
+				Path path = root.get(attr);
+				if (ArrayUtils.isNotEmpty(attrs)) {
+					for (String attribute : attrs)
+						path = path.get(attr);
+				}
+				// Return specification with correct operation
+				switch (operator) {
+					case EQUALS:
+						return criteriaBuilder.equal(path, value);
+					default:
+						throw new IllegalArgumentException(
+								"Operation not supported. Operation must be a member of Operator enum.");
+				}
+			}
+		};
+	}
 
-    /**
-     * Operation types supported by the Specification builder
-     */
-    private enum Operator {
-        EQUALS      // x = y
-    }
+	/**
+	 * Operation types supported by the Specification builder
+	 */
+	private enum Operator {
+		EQUALS // x = y
+	}
 }
 
 

--- a/src/test/java/com/unityTest/courseManagement/CourseManagementApplicationTests.java
+++ b/src/test/java/com/unityTest/courseManagement/CourseManagementApplicationTests.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 class CourseManagementApplicationTests {
 
 	@Test
-	void contextLoads() {
-	}
+	void contextLoads() {}
 
 }

--- a/src/test/java/com/unityTest/courseManagement/TestUtils.java
+++ b/src/test/java/com/unityTest/courseManagement/TestUtils.java
@@ -7,41 +7,42 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 public class TestUtils {
 
-    public static MockHttpServletRequestBuilder get(String url) {
-        return MockMvcRequestBuilders.get(url)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+	public static MockHttpServletRequestBuilder get(String url) {
+		return MockMvcRequestBuilders.get(url).accept(MediaType.APPLICATION_JSON);
+	}
 
-    public static MockHttpServletRequestBuilder post(String url, Object body) {
-        return MockMvcRequestBuilders.post(url)
-                .content(asJsonString(body))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+	public static MockHttpServletRequestBuilder post(String url, Object body) {
+		return MockMvcRequestBuilders
+			.post(url)
+			.content(asJsonString(body))
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON);
+	}
 
-    public static MockHttpServletRequestBuilder put(String url, Object body) {
-        return MockMvcRequestBuilders.put(url)
-                .content(asJsonString(body))
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+	public static MockHttpServletRequestBuilder put(String url, Object body) {
+		return MockMvcRequestBuilders
+			.put(url)
+			.content(asJsonString(body))
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON);
+	}
 
-    public static MockHttpServletRequestBuilder delete(String url) {
-        return MockMvcRequestBuilders.delete(url)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+	public static MockHttpServletRequestBuilder delete(String url) {
+		return MockMvcRequestBuilders.delete(url).accept(MediaType.APPLICATION_JSON);
+	}
 
-    /**
-     * Return a JSON string representation of an object
-     * @param obj Object to serialize as JSON
-     * @throws RuntimeException if object cannot be serialized
-     * @return JSON string representation of object
-     */
-    public static String asJsonString(final Object obj) {
-        try {
-            return new ObjectMapper().writeValueAsString(obj);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+	/**
+	 * Return a JSON string representation of an object
+	 * 
+	 * @param obj Object to serialize as JSON
+	 * @throws RuntimeException if object cannot be serialized
+	 * @return JSON string representation of object
+	 */
+	public static String asJsonString(final Object obj) {
+		try {
+			return new ObjectMapper().writeValueAsString(obj);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/test/java/com/unityTest/courseManagement/rest/CourseApiTests.java
+++ b/src/test/java/com/unityTest/courseManagement/rest/CourseApiTests.java
@@ -37,247 +37,261 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 class CourseApiTests {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @Autowired
-    private CourseRepository courseRepository;
+	@Autowired
+	private CourseRepository courseRepository;
 
-    @Autowired
-    private CourseAttrRepository courseAttrRepository;
+	@Autowired
+	private CourseAttrRepository courseAttrRepository;
 
-    private final String baseUri = "/course";
+	private final String baseUri = "/course";
 
-    @AfterEach
-    void cleanupDB() {
-        courseRepository.deleteAll();
-        courseAttrRepository.deleteAll();
-    }
+	@AfterEach
+	void cleanupDB() {
+		courseRepository.deleteAll();
+		courseAttrRepository.deleteAll();
+	}
 
-    @Test
-    void createCourse_ValidArg_SaveCourseToRepo() throws Exception {
-        final Course courseToCreate = new Course(0, "CREATE_TEST", 1, Term.FALL, 2020);
+	@Test
+	void createCourse_ValidArg_SaveCourseToRepo() throws Exception {
+		final Course courseToCreate = new Course(0, "CREATE_TEST", 1, Term.FALL, 2020);
 
-        // Perform POST request
-        MvcResult result = mockMvc.perform(post(this.baseUri, courseToCreate))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").exists())
-                .andExpect(jsonPath("$.code").value(courseToCreate.getCode()))
-                .andExpect(jsonPath("$.level").value(courseToCreate.getLevel()))
-                .andExpect(jsonPath("$.term").value(courseToCreate.getTerm().toString()))
-                .andExpect(jsonPath("$.academicYear").value(courseToCreate.getAcademicYear()))
-                .andReturn();
-        // Extract id of created course
-        int courseId = JsonPath.read(result.getResponse().getContentAsString(), "$.id");
-        courseToCreate.setId(courseId);
-        // Verify in repository
-        assertThat(courseRepository.findAll()).hasSize(1);
-        assertEquals(courseRepository.findAll().get(0), courseToCreate);
-    }
+		// Perform POST request
+		MvcResult result = mockMvc
+			.perform(post(this.baseUri, courseToCreate))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.id").exists())
+			.andExpect(jsonPath("$.code").value(courseToCreate.getCode()))
+			.andExpect(jsonPath("$.level").value(courseToCreate.getLevel()))
+			.andExpect(jsonPath("$.term").value(courseToCreate.getTerm().toString()))
+			.andExpect(jsonPath("$.academicYear").value(courseToCreate.getAcademicYear()))
+			.andReturn();
+		// Extract id of created course
+		int courseId = JsonPath.read(result.getResponse().getContentAsString(), "$.id");
+		courseToCreate.setId(courseId);
+		// Verify in repository
+		assertThat(courseRepository.findAll()).hasSize(1);
+		assertEquals(courseRepository.findAll().get(0), courseToCreate);
+	}
 
-    @Test
-    void createCourse_MissingRequiredArgs_ValidationError() throws Exception {
-        final Course courseToCreate = new Course(0, null, 6, null, null);
+	@Test
+	void createCourse_MissingRequiredArgs_ValidationError() throws Exception {
+		final Course courseToCreate = new Course(0, null, 6, null, null);
 
-        // Perform POST request
-        mockMvc.perform(post(this.baseUri, courseToCreate))
-                .andExpect(status().isBadRequest())     // Expect a 400 error
-                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.METHOD_ARGUMENT_NOT_VALID))
-                // Check that the validation errors are returned
-                .andExpect(jsonPath("$.subErrors[*].field").value(containsInAnyOrder("code", "academicYear", "term", "level")));
-    }
+		// Perform POST request
+		mockMvc
+			.perform(post(this.baseUri, courseToCreate))
+			.andExpect(status().isBadRequest()) // Expect a 400 error
+			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.METHOD_ARGUMENT_NOT_VALID))
+			// Check that the validation errors are returned
+			.andExpect(
+				jsonPath("$.subErrors[*].field").value(containsInAnyOrder("code", "academicYear", "term", "level")));
+	}
 
-    @Test
-    void createCourse_UniqueConstraintViolation_DataConflictError() throws Exception {
-        // Create mock course to save to database
-        Course course = new Course(0, "CONSTRAINT_CREATE_TEST", 2, Term.FALL, 2020);
+	@Test
+	void createCourse_UniqueConstraintViolation_DataConflictError() throws Exception {
+		// Create mock course to save to database
+		Course course = new Course(0, "CONSTRAINT_CREATE_TEST", 2, Term.FALL, 2020);
 
-        // Perform first POST request
-        mockMvc.perform(post(this.baseUri, course))
-                .andExpect(status().isCreated());       // Verify creation
-        // Perform second request to violate unique constraint
-        mockMvc.perform(post(this.baseUri, course))
-                .andExpect(status().isConflict())       // Expect a 409 status
-                .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.DATABASE_CONFLICT))
-                .andExpect(jsonPath("$.path").value(baseUri));
-        // Verify only one course was created in database
-        assertThat(courseRepository.findAll()).hasSize(1);
-    }
+		// Perform first POST request
+		mockMvc.perform(post(this.baseUri, course)).andExpect(status().isCreated()); // Verify creation
+		// Perform second request to violate unique constraint
+		mockMvc
+			.perform(post(this.baseUri, course))
+			.andExpect(status().isConflict()) // Expect a 409 status
+			.andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.DATABASE_CONFLICT))
+			.andExpect(jsonPath("$.path").value(baseUri));
+		// Verify only one course was created in database
+		assertThat(courseRepository.findAll()).hasSize(1);
+	}
 
-    @Test
-    void getCourses_ValidQuery_GetListOfCourses() throws Exception {
-        // Create mock courses
-        final Course course1 = courseRepository.save(new Course(0, "GET_TEST_1", 1, Term.FALL, 2019));
-        final Course course2 = courseRepository.save(new Course(0, "GET_TEST_2", 2, Term.FALL, 2020));
-        // Perform GET request
-        mockMvc.perform(get(this.baseUri))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.count").value(2))
-                // Check first course
-                .andExpect(jsonPath("$.data[0].id").value(course1.getId()))
-                .andExpect(jsonPath("$.data[0].code").value(course1.getCode()))
-                .andExpect(jsonPath("$.data[0].level").value(course1.getLevel()))
-                .andExpect(jsonPath("$.data[0].term").value(course1.getTerm().toString()))
-                .andExpect(jsonPath("$.data[0].academicYear").value(course1.getAcademicYear()))
-                // Check second course
-                .andExpect(jsonPath("$.data[1].id").value(course2.getId()))
-                .andExpect(jsonPath("$.data[1].code").value(course2.getCode()))
-                .andExpect(jsonPath("$.data[1].level").value(course2.getLevel()))
-                .andExpect(jsonPath("$.data[1].term").value(course2.getTerm().toString()))
-                .andExpect(jsonPath("$.data[1].academicYear").value(course2.getAcademicYear()));
-    }
+	@Test
+	void getCourses_ValidQuery_GetListOfCourses() throws Exception {
+		// Create mock courses
+		final Course course1 = courseRepository.save(new Course(0, "GET_TEST_1", 1, Term.FALL, 2019));
+		final Course course2 = courseRepository.save(new Course(0, "GET_TEST_2", 2, Term.FALL, 2020));
+		// Perform GET request
+		mockMvc
+			.perform(get(this.baseUri))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.count").value(2))
+			// Check first course
+			.andExpect(jsonPath("$.data[0].id").value(course1.getId()))
+			.andExpect(jsonPath("$.data[0].code").value(course1.getCode()))
+			.andExpect(jsonPath("$.data[0].level").value(course1.getLevel()))
+			.andExpect(jsonPath("$.data[0].term").value(course1.getTerm().toString()))
+			.andExpect(jsonPath("$.data[0].academicYear").value(course1.getAcademicYear()))
+			// Check second course
+			.andExpect(jsonPath("$.data[1].id").value(course2.getId()))
+			.andExpect(jsonPath("$.data[1].code").value(course2.getCode()))
+			.andExpect(jsonPath("$.data[1].level").value(course2.getLevel()))
+			.andExpect(jsonPath("$.data[1].term").value(course2.getTerm().toString()))
+			.andExpect(jsonPath("$.data[1].academicYear").value(course2.getAcademicYear()));
+	}
 
-    @Test
-    void deleteCourse_CourseExists_DeleteCourseInRepo() throws Exception {
-        // Create mock course in repository to delete
-        Course course = courseRepository.save(new Course(0, "DELETE_TEST", 1, Term.WINTER, 2000));
-        final String url = String.format("%s/%d", this.baseUri, course.getId());
+	@Test
+	void deleteCourse_CourseExists_DeleteCourseInRepo() throws Exception {
+		// Create mock course in repository to delete
+		Course course = courseRepository.save(new Course(0, "DELETE_TEST", 1, Term.WINTER, 2000));
+		final String url = String.format("%s/%d", this.baseUri, course.getId());
 
-        // Perform DELETE request
-        mockMvc.perform(delete(url))
-                .andExpect(status().isNoContent());
-        // Verify to see if course was deleted
-        assertThat(courseRepository.findAll()).hasSize(0);
-    }
+		// Perform DELETE request
+		mockMvc.perform(delete(url)).andExpect(status().isNoContent());
+		// Verify to see if course was deleted
+		assertThat(courseRepository.findAll()).hasSize(0);
+	}
 
-    @Test
-    void deleteCourse_CourseDoesNotExist_ElementNotFoundError() throws Exception {
-        final String url = String.format("%s/%d", this.baseUri, 1);
+	@Test
+	void deleteCourse_CourseDoesNotExist_ElementNotFoundError() throws Exception {
+		final String url = String.format("%s/%d", this.baseUri, 1);
 
-        // Call delete endpoint, however no courses exist in the database
-        mockMvc.perform(delete(url))
-                .andExpect(status().isNotFound())       // Status should be a 404
-                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.ELEMENT_DOES_NOT_EXIST))
-                .andExpect(jsonPath("$.path").value(url));
-    }
+		// Call delete endpoint, however no courses exist in the database
+		mockMvc
+			.perform(delete(url))
+			.andExpect(status().isNotFound()) // Status should be a 404
+			.andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.ELEMENT_DOES_NOT_EXIST))
+			.andExpect(jsonPath("$.path").value(url));
+	}
 
-    @Test
-    void createCourseAttr_ValidArg_SaveCourseAttrInRepo () throws Exception {
-        // Create course to attach attribute to in repository
-        Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.SUMMER, 2000));
-        final String url = String.format("%s/%d/attr", this.baseUri, course.getId());
-        CourseAttribute courseAttrToCreate = new CourseAttribute(0, null, CourseAttributeName.title, "TEST_VAL");
+	@Test
+	void createCourseAttr_ValidArg_SaveCourseAttrInRepo() throws Exception {
+		// Create course to attach attribute to in repository
+		Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.SUMMER, 2000));
+		final String url = String.format("%s/%d/attr", this.baseUri, course.getId());
+		CourseAttribute courseAttrToCreate = new CourseAttribute(0, null, CourseAttributeName.title, "TEST_VAL");
 
-        // Perform POST request
-        MvcResult result = mockMvc.perform(post(url, courseAttrToCreate))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name").value(courseAttrToCreate.getName().toString()))
-                .andExpect(jsonPath("$.value").value(courseAttrToCreate.getValue()))
-                .andReturn();
-        // Set courseId to check
-        courseAttrToCreate.setCourseId(course.getId());
-        // Verify in repository
-        assertThat(courseAttrRepository.findAll()).hasSize(1);
-        // Check course id, name and value
-        assertEquals(courseAttrRepository.findAll().get(0).getCourseId(), courseAttrToCreate.getCourseId());
-        assertEquals(courseAttrRepository.findAll().get(0).getName(), courseAttrToCreate.getName());
-        assertEquals(courseAttrRepository.findAll().get(0).getValue(), courseAttrToCreate.getValue());
-    }
+		// Perform POST request
+		MvcResult result = mockMvc
+			.perform(post(url, courseAttrToCreate))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.name").value(courseAttrToCreate.getName().toString()))
+			.andExpect(jsonPath("$.value").value(courseAttrToCreate.getValue()))
+			.andReturn();
+		// Set courseId to check
+		courseAttrToCreate.setCourseId(course.getId());
+		// Verify in repository
+		assertThat(courseAttrRepository.findAll()).hasSize(1);
+		// Check course id, name and value
+		assertEquals(courseAttrRepository.findAll().get(0).getCourseId(), courseAttrToCreate.getCourseId());
+		assertEquals(courseAttrRepository.findAll().get(0).getName(), courseAttrToCreate.getName());
+		assertEquals(courseAttrRepository.findAll().get(0).getValue(), courseAttrToCreate.getValue());
+	}
 
-    @Test
-    void createCourseAttr_CourseDoesNotExist_ElementNotFoundError() throws Exception {
-        final String url = String.format("%s/%d/attr", this.baseUri, 1);
+	@Test
+	void createCourseAttr_CourseDoesNotExist_ElementNotFoundError() throws Exception {
+		final String url = String.format("%s/%d/attr", this.baseUri, 1);
 
-        // Create CourseAttribute to save to repo
-        CourseAttribute courseAttribute = new CourseAttribute(0, null, CourseAttributeName.title, "TEST_VAL");
+		// Create CourseAttribute to save to repo
+		CourseAttribute courseAttribute = new CourseAttribute(0, null, CourseAttributeName.title, "TEST_VAL");
 
-        // Perform post request
-        mockMvc.perform(post(url, courseAttribute))
-                .andExpect(status().isNotFound())       // Expect a 404 error
-                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.ELEMENT_NOT_FOUND))
-                .andExpect(jsonPath("$.path").value(url));
-    }
+		// Perform post request
+		mockMvc
+			.perform(post(url, courseAttribute))
+			.andExpect(status().isNotFound()) // Expect a 404 error
+			.andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.ELEMENT_NOT_FOUND))
+			.andExpect(jsonPath("$.path").value(url));
+	}
 
-    @Test
-    void createCourseAttr_MissingRequiredArgs_ValidationError() throws Exception {
-        // Create course to attach attribute to in repository
-        Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.SUMMER, 2000));
-        final String url = String.format("%s/%d/attr", this.baseUri, course.getId());
+	@Test
+	void createCourseAttr_MissingRequiredArgs_ValidationError() throws Exception {
+		// Create course to attach attribute to in repository
+		Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.SUMMER, 2000));
+		final String url = String.format("%s/%d/attr", this.baseUri, course.getId());
 
-        // Create CourseAttribute missing name and value
-        CourseAttribute courseAttribute = new CourseAttribute(0, null, null, null);
+		// Create CourseAttribute missing name and value
+		CourseAttribute courseAttribute = new CourseAttribute(0, null, null, null);
 
-        // Perform POST request
-        mockMvc.perform(post(url, courseAttribute))
-                .andExpect(status().isBadRequest())     // Expect a 400 error
-                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.METHOD_ARGUMENT_NOT_VALID))
-                // Check that the validation errors are returned
-                .andExpect(jsonPath("$.subErrors[*].field").value(containsInAnyOrder("name", "value")));
-    }
+		// Perform POST request
+		mockMvc
+			.perform(post(url, courseAttribute))
+			.andExpect(status().isBadRequest()) // Expect a 400 error
+			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.METHOD_ARGUMENT_NOT_VALID))
+			// Check that the validation errors are returned
+			.andExpect(jsonPath("$.subErrors[*].field").value(containsInAnyOrder("name", "value")));
+	}
 
-    @Test
-    void createCourseAttr_AttributeNameAlreadyExists_OverwriteAttributeValue() throws Exception {
-        // Create course to attach attribute to in repository
-        Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.SUMMER, 2000));
-        final String url = String.format("%s/%d/attr", this.baseUri, course.getId());
+	@Test
+	void createCourseAttr_AttributeNameAlreadyExists_OverwriteAttributeValue() throws Exception {
+		// Create course to attach attribute to in repository
+		Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.SUMMER, 2000));
+		final String url = String.format("%s/%d/attr", this.baseUri, course.getId());
 
-        // Create CourseAttribute to save (twice) to repo
-        CourseAttribute courseAttribute = new CourseAttribute(0, null, CourseAttributeName.title, "TEST_VAL");
+		// Create CourseAttribute to save (twice) to repo
+		CourseAttribute courseAttribute = new CourseAttribute(0, null, CourseAttributeName.title, "TEST_VAL");
 
-        // Perform first POST request
-        mockMvc.perform(post(url, courseAttribute))
-                .andExpect(status().isCreated())        // Verify 201 on first request
-                .andExpect(jsonPath("$.value").value(courseAttribute.getValue()));
+		// Perform first POST request
+		mockMvc
+			.perform(post(url, courseAttribute))
+			.andExpect(status().isCreated()) // Verify 201 on first request
+			.andExpect(jsonPath("$.value").value(courseAttribute.getValue()));
 
-        // Set new value
-        courseAttribute.setValue("NEW_TEST_VAL");
-        // Perform second POST request to overwrite the first value
-        mockMvc.perform(post(url, courseAttribute))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name").value(courseAttribute.getName().toString()))
-                .andExpect(jsonPath("$.value").value(courseAttribute.getValue()))
-                .andReturn();
-        // Verify only one course attribute is in database
-        assertThat(courseAttrRepository.findAll()).hasSize(1);
-        // Check that value is overwritten
-        assertEquals(courseAttrRepository.findAll().get(0).getValue(), courseAttribute.getValue());
-    }
+		// Set new value
+		courseAttribute.setValue("NEW_TEST_VAL");
+		// Perform second POST request to overwrite the first value
+		mockMvc
+			.perform(post(url, courseAttribute))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.name").value(courseAttribute.getName().toString()))
+			.andExpect(jsonPath("$.value").value(courseAttribute.getValue()))
+			.andReturn();
+		// Verify only one course attribute is in database
+		assertThat(courseAttrRepository.findAll()).hasSize(1);
+		// Check that value is overwritten
+		assertEquals(courseAttrRepository.findAll().get(0).getValue(), courseAttribute.getValue());
+	}
 
-    @Test
-    void getCourseAttrs_ValidQuery_ReturnListOfCourseAttributes() throws Exception {
-        Course course = courseRepository.save(new Course(0, "TEST_GET_COURSE_ATTR", 1, Term.WINTER, 2020));
-        String url = String.format("%s/%d/attr", this.baseUri, course.getId());
-        // Create mock entities
-        CourseAttribute attr1 = courseAttrRepository.save(new CourseAttribute(0, course.getId(), CourseAttributeName.title, "TEST_VAL_1"));
-        CourseAttribute attr2 = courseAttrRepository.save(new CourseAttribute(0, course.getId(), CourseAttributeName.professorName, "TEST_VAL_2"));
+	@Test
+	void getCourseAttrs_ValidQuery_ReturnListOfCourseAttributes() throws Exception {
+		Course course = courseRepository.save(new Course(0, "TEST_GET_COURSE_ATTR", 1, Term.WINTER, 2020));
+		String url = String.format("%s/%d/attr", this.baseUri, course.getId());
+		// Create mock entities
+		CourseAttribute attr1 =
+			courseAttrRepository.save(new CourseAttribute(0, course.getId(), CourseAttributeName.title, "TEST_VAL_1"));
+		CourseAttribute attr2 = courseAttrRepository
+			.save(new CourseAttribute(0, course.getId(), CourseAttributeName.professorName, "TEST_VAL_2"));
 
-        // Perform GET request
-        mockMvc.perform(get(url))
-                .andExpect(status().isOk())
-                // Check title
-                .andExpect(jsonPath("$.title").value(attr1.getValue()))
-                // Check professorName
-                .andExpect(jsonPath("$.professorName").value(attr2.getValue()));
-    }
+		// Perform GET request
+		mockMvc
+			.perform(get(url))
+			.andExpect(status().isOk())
+			// Check title
+			.andExpect(jsonPath("$.title").value(attr1.getValue()))
+			// Check professorName
+			.andExpect(jsonPath("$.professorName").value(attr2.getValue()));
+	}
 
-    @Test
-    void deleteCourseAttr_CourseAttributeExists_DeleteCourseAttributeInRepo() throws Exception {
-        // Create mock courseAttribute in repository to delete
-        Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.WINTER, 2000));
-        CourseAttribute courseAttribute = courseAttrRepository.save(new CourseAttribute(0, course.getId(), CourseAttributeName.title, "TEST_VALUE"));
-        final String url = String.format("%s/%d/attr/%s", this.baseUri, course.getId(), courseAttribute.getName().toString());
+	@Test
+	void deleteCourseAttr_CourseAttributeExists_DeleteCourseAttributeInRepo() throws Exception {
+		// Create mock courseAttribute in repository to delete
+		Course course = courseRepository.save(new Course(0, "TEST_CODE", 1, Term.WINTER, 2000));
+		CourseAttribute courseAttribute =
+			courseAttrRepository.save(new CourseAttribute(0, course.getId(), CourseAttributeName.title, "TEST_VALUE"));
+		final String url =
+			String.format("%s/%d/attr/%s", this.baseUri, course.getId(), courseAttribute.getName().toString());
 
-        // Perform DELETE request
-        mockMvc.perform(delete(url))
-                .andExpect(status().isNoContent());
-        // Check to see if course attribute was deleted
-        assertThat(courseAttrRepository.findAll()).hasSize(0);
-    }
+		// Perform DELETE request
+		mockMvc.perform(delete(url)).andExpect(status().isNoContent());
+		// Check to see if course attribute was deleted
+		assertThat(courseAttrRepository.findAll()).hasSize(0);
+	}
 
-    @Test
-    void deleteCourseAttr_CourseAttributeNameDoesNotExist_ElementNotFoundError() throws Exception {
-        final String url = String.format("%s/%d/attr/%s", this.baseUri, 1, "INVALID_ATTR_NAME");
+	@Test
+	void deleteCourseAttr_CourseAttributeNameDoesNotExist_ElementNotFoundError() throws Exception {
+		final String url = String.format("%s/%d/attr/%s", this.baseUri, 1, "INVALID_ATTR_NAME");
 
-        // Call delete endpoint, no CourseAttributeName with the name INVALID_ATTR_NAME exists
-        mockMvc.perform(delete(url))
-                .andExpect(status().isBadRequest())       // Status should be a 400
-                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.MALFORMED_JSON_REQUEST))
-                .andExpect(jsonPath("$.path").value(url));
-    }
+		// Call delete endpoint, no CourseAttributeName with the name INVALID_ATTR_NAME exists
+		mockMvc
+			.perform(delete(url))
+			.andExpect(status().isBadRequest()) // Status should be a 400
+			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.MALFORMED_JSON_REQUEST))
+			.andExpect(jsonPath("$.path").value(url));
+	}
 }

--- a/src/test/java/com/unityTest/courseManagement/rest/RestExceptionHandlerTests.java
+++ b/src/test/java/com/unityTest/courseManagement/rest/RestExceptionHandlerTests.java
@@ -30,103 +30,113 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 class RestExceptionHandlerTests {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    // Course endpoint
-    private String courseURI = "/course";
+	// Course endpoint
+	private String courseURI = "/course";
 
-    /**
-     * Test MissingServletRequestParameterException handler when request is missing required parameter.
-     */
-    @Test
-    void handleMissingServletRequestParameter_missingRequiredParam_BadRequestError() throws Exception {
-        // TODO Implement MissingServletRequestParameter test once an endpoint that can this error exists
-    }
+	/**
+	 * Test MissingServletRequestParameterException handler when request is missing required parameter.
+	 */
+	@Test
+	void handleMissingServletRequestParameter_missingRequiredParam_BadRequestError() throws Exception {
+		// TODO Implement MissingServletRequestParameter test once an endpoint that can this error exists
+	}
 
-    /*
-        Test HttpMediaTypeNotSupported handler when request header Content-Type is set to include unsupported media type.
-     */
-    @Test
-    void handleHttpMediaTypeNotSupported_BadMediaType_UnsupportedMediaTypeError() throws Exception {
-        final Course course = new Course(0, "TEST", 1, Term.FALL, 2020);
-        final String uri = this.courseURI;
+	/*
+	 * Test HttpMediaTypeNotSupported handler when request header Content-Type is set to include
+	 * unsupported media type.
+	 */
+	@Test
+	void handleHttpMediaTypeNotSupported_BadMediaType_UnsupportedMediaTypeError() throws Exception {
+		final Course course = new Course(0, "TEST", 1, Term.FALL, 2020);
+		final String uri = this.courseURI;
 
-        mockMvc.perform(MockMvcRequestBuilders.post(uri)
-                .content(asJsonString(course))
-                .contentType(MediaType.IMAGE_PNG)
-                .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isUnsupportedMediaType())       // Expect a 415 status to be returned
-                .andExpect(jsonPath("$.code").value(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value()))
-                .andExpect(jsonPath("$.status").value(HttpStatus.UNSUPPORTED_MEDIA_TYPE.name()))
-                .andExpect(jsonPath("$.path").value(uri));
-    }
+		mockMvc
+			.perform(
+				MockMvcRequestBuilders
+					.post(uri)
+					.content(asJsonString(course))
+					.contentType(MediaType.IMAGE_PNG)
+					.accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isUnsupportedMediaType()) // Expect a 415 status to be returned
+			.andExpect(jsonPath("$.code").value(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.UNSUPPORTED_MEDIA_TYPE.name()))
+			.andExpect(jsonPath("$.path").value(uri));
+	}
 
-    /**
-     * Test HttpRequestMethodNotSupportException
-     */
-    @Test
-    void handleHttpRequestMethodNotSupported_InvalidHttpVerb_MethodNotAllowedError() throws Exception {
-        final String uri = this.courseURI;
+	/**
+	 * Test HttpRequestMethodNotSupportException
+	 */
+	@Test
+	void handleHttpRequestMethodNotSupported_InvalidHttpVerb_MethodNotAllowedError() throws Exception {
+		final String uri = this.courseURI;
 
-        // Call DELETE on /course endpoint. /course only supports POST and GET Http verbs
-        mockMvc.perform(delete(uri))
-                .andExpect(status().isMethodNotAllowed())       // Expect a 405 status to be returned
-                .andExpect(jsonPath("$.code").value(HttpStatus.METHOD_NOT_ALLOWED.value()))
-                .andExpect(jsonPath("$.status").value(HttpStatus.METHOD_NOT_ALLOWED.name()))
-                .andExpect(jsonPath("$.path").value(uri));
-    }
+		// Call DELETE on /course endpoint. /course only supports POST and GET Http verbs
+		mockMvc
+			.perform(delete(uri))
+			.andExpect(status().isMethodNotAllowed()) // Expect a 405 status to be returned
+			.andExpect(jsonPath("$.code").value(HttpStatus.METHOD_NOT_ALLOWED.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.METHOD_NOT_ALLOWED.name()))
+			.andExpect(jsonPath("$.path").value(uri));
+	}
 
-    /**
-     * Test NoHandlerFoundException handler for request to unsupported path.
-     * TODO Add test once NoHandlerFoundException added to RestExceptionHanlder
-     */
-    void handleNotHandlerFoundException_InvalidPath_NotFoundError() throws Exception {
-        final String uri = "/invalidPath";      // Create some invalid path that does not exist
+	/**
+	 * Test NoHandlerFoundException handler for request to unsupported path. TODO Add test once
+	 * NoHandlerFoundException added to RestExceptionHanlder
+	 */
+	void handleNotHandlerFoundException_InvalidPath_NotFoundError() throws Exception {
+		final String uri = "/invalidPath"; // Create some invalid path that does not exist
 
-        // Call DELETE on invalid path
-        mockMvc.perform(get(uri))
-                .andDo(print())
-                .andExpect(status().isNotFound())       // Expect a 404 status code
-                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
-                .andExpect(jsonPath("$.path").value(uri));
-    }
+		// Call DELETE on invalid path
+		mockMvc
+			.perform(get(uri))
+			.andDo(print())
+			.andExpect(status().isNotFound()) // Expect a 404 status code
+			.andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+			.andExpect(jsonPath("$.path").value(uri));
+	}
 
-    /**
-     * Test HttpMessageNotReadableException handler for request with malformed JSON body.
-     */
-    @Test
-    void handleHttpMessageNotReadable_MalformedJson_BadRequestError() throws Exception {
-        final String uri = this.courseURI;
-        final String malformedJsonBody = "{\n\t\"code\":\"Test\",";     // Create JSON missing closing bracket
+	/**
+	 * Test HttpMessageNotReadableException handler for request with malformed JSON body.
+	 */
+	@Test
+	void handleHttpMessageNotReadable_MalformedJson_BadRequestError() throws Exception {
+		final String uri = this.courseURI;
+		final String malformedJsonBody = "{\n\t\"code\":\"Test\","; // Create JSON missing closing bracket
 
-        // Call /course endpoint with malformed JSON body
-        mockMvc.perform(MockMvcRequestBuilders.post(uri)
-                .content(malformedJsonBody)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())     // Expect a 400 status to be returned
-                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
-                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.MALFORMED_JSON_REQUEST))
-                .andExpect(jsonPath("$.path").value(uri));
-    }
+		// Call /course endpoint with malformed JSON body
+		mockMvc
+			.perform(
+				MockMvcRequestBuilders
+					.post(uri)
+					.content(malformedJsonBody)
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest()) // Expect a 400 status to be returned
+			.andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.MALFORMED_JSON_REQUEST))
+			.andExpect(jsonPath("$.path").value(uri));
+	}
 
-    /**
-     * Test PropertyReferenceException handler for request with pagination sorting referencing
-     * field not in object.
-     */
-    @Test
-    void handlePropertyReferenceException_BadPaginationSorting_NotFoundError() throws Exception {
-        final String uri = String.format("%s?sort=%s,asc", this.courseURI, "xx");
+	/**
+	 * Test PropertyReferenceException handler for request with pagination sorting referencing field not
+	 * in object.
+	 */
+	@Test
+	void handlePropertyReferenceException_BadPaginationSorting_NotFoundError() throws Exception {
+		final String uri = String.format("%s?sort=%s,asc", this.courseURI, "xx");
 
-        // Call GET endpoint and try to sort by property 'xx' which doesn't exist in course object
-        mockMvc.perform(get(uri))
-                .andExpect(status().isNotFound())       // Expect a 404 status to be returned
-                .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
-                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
-                .andExpect(jsonPath("$.message").value(ExceptionMsg.PROPERTY_REFERENCE))
-                .andExpect(jsonPath("$.path").value(this.courseURI));
-    }
+		// Call GET endpoint and try to sort by property 'xx' which doesn't exist in course object
+		mockMvc
+			.perform(get(uri))
+			.andExpect(status().isNotFound()) // Expect a 404 status to be returned
+			.andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.name()))
+			.andExpect(jsonPath("$.message").value(ExceptionMsg.PROPERTY_REFERENCE))
+			.andExpect(jsonPath("$.path").value(this.courseURI));
+	}
 }

--- a/src/test/java/com/unityTest/courseManagement/service/CourseServiceTests.java
+++ b/src/test/java/com/unityTest/courseManagement/service/CourseServiceTests.java
@@ -34,93 +34,93 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CourseServiceTests {
 
-    @Mock
-    private CourseRepository courseRepository;
+	@Mock
+	private CourseRepository courseRepository;
 
-    @Mock
-    private CourseAttrRepository courseAttrRepository;
+	@Mock
+	private CourseAttrRepository courseAttrRepository;
 
-    @InjectMocks
-    private CourseService courseService;
+	@InjectMocks
+	private CourseService courseService;
 
-    // Mock course
-    private Course course;
+	// Mock course
+	private Course course;
 
-    // Mock course list
-    private List<Course> courseList;
+	// Mock course list
+	private List<Course> courseList;
 
-    // Mock course attribute
-    private CourseAttribute courseAttribute;
+	// Mock course attribute
+	private CourseAttribute courseAttribute;
 
-    // Mock course attribute list
-    private List<CourseAttribute> courseAttributeList;
+	// Mock course attribute list
+	private List<CourseAttribute> courseAttributeList;
 
-    @BeforeEach
-    void setup() {
-        // Setup course
-        course = new Course(1, "TEST COURSE CODE", 1, Term.WINTER, 2000);
-        // Setup course list
-        courseList = new ArrayList<>();
-        courseList.add(course);
+	@BeforeEach
+	void setup() {
+		// Setup course
+		course = new Course(1, "TEST COURSE CODE", 1, Term.WINTER, 2000);
+		// Setup course list
+		courseList = new ArrayList<>();
+		courseList.add(course);
 
-        // Setup course attribute
-        courseAttribute = new CourseAttribute(1, 1, CourseAttributeName.title, "TEST VALUE");
-        // Setup course attribute list
-        courseAttributeList = new ArrayList<>();
-        courseAttributeList.add(courseAttribute);
-    }
+		// Setup course attribute
+		courseAttribute = new CourseAttribute(1, 1, CourseAttributeName.title, "TEST VALUE");
+		// Setup course attribute list
+		courseAttributeList = new ArrayList<>();
+		courseAttributeList.add(courseAttribute);
+	}
 
-    @Test
-    void createCourse_Valid_ReturnCreatedCourse() {
-        when(this.courseRepository.save(any(Course.class))).then(returnsFirstArg());
-        assertEquals(course, courseService.createCourse(course));
-    }
+	@Test
+	void createCourse_Valid_ReturnCreatedCourse() {
+		when(this.courseRepository.save(any(Course.class))).then(returnsFirstArg());
+		assertEquals(course, courseService.createCourse(course));
+	}
 
-    @Test
-    void getCourses_Valid_ReturnCourseList() {
-        Page<Course> page = new PageImpl<>(courseList);
-        when(this.courseRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
-        assertEquals(courseList, courseService.getCourses(1, "COMPSCI 1JC3", 1, Term.WINTER, 2000));
-    }
+	@Test
+	void getCourses_Valid_ReturnCourseList() {
+		Page<Course> page = new PageImpl<>(courseList);
+		when(this.courseRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+		assertEquals(courseList, courseService.getCourses(1, "COMPSCI 1JC3", 1, Term.WINTER, 2000));
+	}
 
-    /**
-     * Test element not found for GetCourseById
-     */
-    @Test
-    void getCourseById_CourseNotFound_ElementNotFoundException() {
-        assertThrows(ElementNotFoundException.class, () -> {
-            when(this.courseRepository.findById(1)).thenReturn(Optional.empty());  // Set repository to not find element
-            courseService.getCourseById(1);
-        });
-    }
+	/**
+	 * Test element not found for GetCourseById
+	 */
+	@Test
+	void getCourseById_CourseNotFound_ElementNotFoundException() {
+		assertThrows(ElementNotFoundException.class, () -> {
+			when(this.courseRepository.findById(1)).thenReturn(Optional.empty()); // Set repository to not find element
+			courseService.getCourseById(1);
+		});
+	}
 
-    @Test
-    void getCourseById_CourseFound_ReturnCourse() {
-        when(this.courseRepository.findById(1)).thenReturn(Optional.of(course));
-        assertEquals(course, courseService.getCourseById(1));
-    }
+	@Test
+	void getCourseById_CourseFound_ReturnCourse() {
+		when(this.courseRepository.findById(1)).thenReturn(Optional.of(course));
+		assertEquals(course, courseService.getCourseById(1));
+	}
 
-    @Test
-    void deleteCourse_Valid_DeleteCourse() {
-        courseService.deleteCourse(1);
-    }
+	@Test
+	void deleteCourse_Valid_DeleteCourse() {
+		courseService.deleteCourse(1);
+	}
 
-    @Test
-    void createCourseAttr_Valid_ReturnCourseAttributeCreated() {
-        when(this.courseAttrRepository.save(any(CourseAttribute.class))).then(returnsFirstArg());
-        assertEquals(courseAttribute, courseService.createCourseAttr(courseAttribute));
-    }
+	@Test
+	void createCourseAttr_Valid_ReturnCourseAttributeCreated() {
+		when(this.courseAttrRepository.save(any(CourseAttribute.class))).then(returnsFirstArg());
+		assertEquals(courseAttribute, courseService.createCourseAttr(courseAttribute));
+	}
 
-    @Test
-    void getCourseAttributes_Valid_ReturnCourseAttributeList() {
-        Page<CourseAttribute> page = new PageImpl<>(courseAttributeList);
-        when(this.courseAttrRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
-        assertEquals(courseAttributeList, courseService.getCourseAttributes(1, 1, CourseAttributeName.title));
-    }
+	@Test
+	void getCourseAttributes_Valid_ReturnCourseAttributeList() {
+		Page<CourseAttribute> page = new PageImpl<>(courseAttributeList);
+		when(this.courseAttrRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+		assertEquals(courseAttributeList, courseService.getCourseAttributes(1, 1, CourseAttributeName.title));
+	}
 
-    @Test
-    void deleteCourseAttr_Valid_DeleteCourseAttribute() {
-        courseService.deleteCourseAttr(1);
-    }
+	@Test
+	void deleteCourseAttr_Valid_DeleteCourseAttribute() {
+		courseService.deleteCourseAttr(1);
+	}
 }
 

--- a/style.xml
+++ b/style.xml
@@ -31,7 +31,7 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_local_variable_declaration" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="1040"/>
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="48"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>

--- a/style.xml
+++ b/style.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+    <profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_prefer_two_fragments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_comment_inline_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_local_variable_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="1040"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression.count_dependent" value="16|4|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration.count_dependent" value="16|4|49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="36"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16"/>
+        <setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_local_variable_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants.count_dependent" value="16|5|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="52"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="20"/>
+        <setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_type_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_field_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comment_prefix" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_parameter_annotation" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter.count_dependent" value="1040|-1|1040"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.force_if_else_statement_brace" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="3"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_package_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585"/>
+        <setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="32"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_new_anonymous_class" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="52"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_member_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_for_statement" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never" />
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never" />
+    </profile>
+</profiles>


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of your changes. -->
Adds an automatic formatted that uses the same formatting rules based on eclipse to format source code files.
Closes #11 

This change is a
- [ ] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [x] Documentation update

## Description
<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added -->
 - Add a new plugin to automatically format code by running the `formatter:format` command. Also bound to the `format` goal of the `compile` lifecycle phase.
 - Add new `.hooks` directory to allow for automatic code formatting before commiting to ensure that status checks don't failed when trying to make a PR.
 - Update Readme with hooks instructions.

## Motivation/Links
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
This will ensure that developers with different styles don't have different styles in the codebases. It also makes the git diffs a little easier to track and read.

## How was this tested?
<!-- How were these changes tested? -->
Multiple iterations of testing formatting style changes. No actual code or functionality differences.

## Todos
- [x] Ensure unit tests pass
- [x] Update documentation for changes (if necessary)
- [x] Delete stale branch after merge