### PR TITLE
Feature/add spring config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<keycloak.version>13.0.1</keycloak.version>
 		<project.scm.id>github</project.scm.id>
 		<git.repository>puffproject/course-management</git.repository>
+		<spring.cloud-version>Hoxton.SR8</spring.cloud-version>
 	</properties>
 
 	<scm>
@@ -48,6 +49,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
 		</dependency>
 
 		<dependency>
@@ -157,6 +163,13 @@
 				<groupId>org.keycloak.bom</groupId>
 				<artifactId>keycloak-adapter-bom</artifactId>
 				<version>${keycloak.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring.cloud-version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/main/java/com/unityTest/courseManagement/configuration/KeycloakSecurityConfig.java
+++ b/src/main/java/com/unityTest/courseManagement/configuration/KeycloakSecurityConfig.java
@@ -40,6 +40,9 @@ public class KeycloakSecurityConfig extends KeycloakWebSecurityConfigurerAdapter
 			.permitAll()
 			.antMatchers("/actuator/info")
 			.permitAll()
+			// Protect refresh endpoint with ADMIN role
+			.antMatchers("/actuator/refresh")
+			.hasRole("ADMIN")
 			// Authorize all other requests
 			.mvcMatchers("/**")
 			.hasRole("USER")

--- a/src/main/java/com/unityTest/courseManagement/configuration/Swagger2Config.java
+++ b/src/main/java/com/unityTest/courseManagement/configuration/Swagger2Config.java
@@ -6,6 +6,7 @@ import com.unityTest.courseManagement.utils.AnnotationProxy;
 import io.swagger.annotations.ApiParam;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -25,6 +26,7 @@ import java.util.*;
 
 import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
+@RefreshScope
 @Configuration
 @EnableSwagger2
 public class Swagger2Config {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,10 +49,7 @@ management:
     port: 8080
     address: 127.0.0.1
   endpoints:
-    enabled-by-default: false
-  endpoint:
-    health.enabled: true
-    info.enabled: true
+    web.exposure.include: health,info,refresh
 
 keycloak:
   realm: puff

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: course-management

--- a/src/main/resources/bootstrap-cloud.yml
+++ b/src/main/resources/bootstrap-cloud.yml
@@ -1,0 +1,6 @@
+# TODO Add cloud config details + security for deployment
+#spring:
+#  cloud:
+#    config:
+#      uri: http://localhost:8888
+#      fail-fast: false

--- a/src/main/resources/bootstrap-local.yml
+++ b/src/main/resources/bootstrap-local.yml
@@ -1,0 +1,6 @@
+spring:
+  cloud:
+    config:
+      uri: http://localhost:8888
+      fail-fast: false
+      request-connect-timeout: 400


### PR DESCRIPTION
## Overview
<!-- Give a brief overview of your changes. -->
Adds spring cloud config client to the course-management microservice to support externalizing configuration. This will come in handy once we deploy to the cloud and need to manage configuration easily.

closes #6. 

New config server microservice: https://github.com/puffproject/config-server
New configuration repo for public config: https://github.com/puffproject/cloud-configuration

This change is a
- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Description
<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added -->
 - Add spring-cloud-starter-config dependency + spring-cloud-dependencies dependency manager. (Simplifies things for eureka later)
 - Updates actuator endpoints to also include `refresh`: Allows to refresh configuration just by hitting an endpoint. 
 - Added the `@RefreshScope` annotation on Swagger config class. Annotation can be used anywhere updateable config values are injected.
 - Added bootstrap.yml files to local spring cloud config details for connecting with the config server (bootstrap is loaded before application files)

## Motivation/Links
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
This supports the DevOps principle of externalizing configuration in applications. With this we can securly pull configuration from the config server when deploying to the cloud. It also allows refreshing of the configuration on-the-fly instead of having to redeploy.

## How was this tested?
<!-- How were these changes tested? -->
Automated tests pass. Also manually tested connection between microservice & config server works. Automated intergration tests to follow.

## Todos
- [x] Ensure unit tests pass
- [ ] Update documentation for changes (if necessary)
- [x] Delete stale branch after merge